### PR TITLE
Fix image tag resolution for deploy stage

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -66,6 +66,9 @@ phases:
           docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/muckrock_celeryworker:$DEPLOYMENT_ENV-`cat commit_hash`
           docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/muckrock_celeryworker:$DEPLOYMENT_ENV-latest
 
-
           aws --region $AWS_DEFAULT_REGION ssm put-parameter --overwrite --name "/deployments/muckrock_django/$DEPLOYMENT_ENV-latest" --value $DEPLOYMENT_ENV-`cat commit_hash` --type String
+          aws --region $AWS_DEFAULT_REGION ssm put-parameter --overwrite --name "/deployments/muckrock_nginx/$DEPLOYMENT_ENV-latest" --value $DEPLOYMENT_ENV-`cat commit_hash` --type String
+          aws --region $AWS_DEFAULT_REGION ssm put-parameter --overwrite --name "/deployments/muckrock_celeryworker/$DEPLOYMENT_ENV-latest" --value $DEPLOYMENT_ENV-`cat commit_hash` --type String
+          aws --region $AWS_DEFAULT_REGION ssm put-parameter --overwrite --name "/deployments/muckrock_celerybeat/$DEPLOYMENT_ENV-latest" --value $DEPLOYMENT_ENV-`cat commit_hash` --type String
+
         done

--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -55,6 +55,7 @@ context:
   # Required
   container:
     name: muckrock_django
+    image: muckrock_django
     port: 8000
     memory_reservation: 512
     # Not required, map of environment variables
@@ -72,11 +73,14 @@ context:
   # Not required, other companion containers
   other_containers:
     - name: muckrock_nginx
+      image: muckrock_nginx
       port: 8000
       health_check:
         - ["CMD-SHELL", "curl -f http://localhost/health || exit 1"]
     - name: muckrock_celerybeat
+      image: muckrock_celerybeat
     - name: muckrock_celeryworker
+      image: muckrock_celeryworker
 params:
   # define the cluster name to run the service on
   ClusterName: newsroom-dev

--- a/cfn/templates/ecs-service.template.yml
+++ b/cfn/templates/ecs-service.template.yml
@@ -148,7 +148,7 @@ Parameters:
     ImageVersion:
         Description: Version to deploy
         Type: 'AWS::SSM::Parameter::Value<String>'
-        Default: /deployments/{{ container.image if container.image is defined else service.image if service.image is defined }}/latest
+        Default: /deployments/{{ container.image if container.image is defined else service.image if service.image is defined }}/{{ environment }}-latest
     {% else %}
     ImageVersion:
         Description: Version to deploy


### PR DESCRIPTION
The ECS service was failing to start up tasks because it was trying to pull images from 
`---.dkr.ecr.us-east-1.amazonaws.com/muckrock_nginx:latest` but we were tagging everything as `DEPLOYMENT_ENV-latest`. For some reason the ecs service template we generated for this repo didn't have the env prefix. It was in the django media browser template, so I added it here. I realized we were also only pushing one tag to SSM for deployment, for django. I added tag pushes for each container. 

Related error:
<img width="1145" alt="Screen Shot 2021-02-23 at 2 13 10 PM" src="https://user-images.githubusercontent.com/6980388/108895376-7e2e7f80-75e1-11eb-9cb1-11bd69538f60.png">


I also added an explicit container image name since the ecs service template reads from that first, to make sure it picks up the right image repository name. 