### PR TITLE
Change container order in config

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -69,8 +69,6 @@ context:
     - name: muckrock_django
       image: muckrock_django
       port: 5000
-      # health_check:
-      #   - ["CMD-SHELL", "curl -f http://localhost/health || exit 1"]
       environment:
         AWS_STORAGE_BUCKET_NAME: wapo-muckrock-dev
         POSTGRES_PORT: 5432

--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -37,7 +37,7 @@ context:
     health_check_path: /
 
     # health check info and defaults
-    health_check_interval_seconds: 30
+    health_check_interval_seconds: 60
     # healthy_threshold_count: 2
     # unhealthy_threshold_count: 6
     health_check_timeout_seconds: 20
@@ -54,15 +54,10 @@ context:
 
   # Required
   container:
-    name: muckrock_django
-    image: muckrock_django
+    name: muckrock_nginx
+    image: muckrock_nginx
     memory_reservation: 512
     # Not required, map of environment variables
-    environment:
-      AWS_STORAGE_BUCKET_NAME: wapo-muckrock-dev
-      POSTGRES_PORT: 5432
-      DJANGO_SETTINGS_MODULE: muckrock.settings.staging
-      ALLOWED_HOSTS: "*"
     # Not required, additional cloudformation properties
     cfn_properties:
       ExtraHosts:
@@ -71,12 +66,17 @@ context:
 
   # Not required, other companion containers
   other_containers:
-    - name: muckrock_nginx
-      image: muckrock_nginx
-      port: 80
-      links: muckrock_django:muckrock_django
+    - name: muckrock_django
+      image: muckrock_django
+      port: 5000
       # health_check:
       #   - ["CMD-SHELL", "curl -f http://localhost/health || exit 1"]
+      environment:
+        AWS_STORAGE_BUCKET_NAME: wapo-muckrock-dev
+        POSTGRES_PORT: 5432
+        DJANGO_SETTINGS_MODULE: muckrock.settings.staging
+        ALLOWED_HOSTS: "*"
+
     - name: muckrock_celerybeat
       image: muckrock_celerybeat
       environment:

--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -37,7 +37,7 @@ context:
     health_check_path: /
 
     # health check info and defaults
-    health_check_interval_seconds: 60
+    health_check_interval_seconds: 30
     # healthy_threshold_count: 2
     # unhealthy_threshold_count: 6
     health_check_timeout_seconds: 20

--- a/compose/dev/django/nginx.conf
+++ b/compose/dev/django/nginx.conf
@@ -17,7 +17,7 @@ http {
   }
 
   server {
-    listen 80;
+    listen 8080;
     charset utf-8;
 
     location /health {


### PR DESCRIPTION
@jasonbartz suggesting using `muckrock_nginx` as the primary container in the task definition instead of django, mostly so it can use the port set by the load balancer, which for `nginx` is 80. Django needs 5000 so it got bumped and can use an explicit `port` declaration in the config. 