### PR TITLE
Move muckrock to new account

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -96,4 +96,4 @@ context:
 
 params:
   # define the cluster name to run the service on
-  ClusterName: muckrock-dev
+  ClusterName: foia-dev

--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -1,4 +1,3 @@
-template: cfn/templates/ecs-service.template.yml
 stack_name: muckrock-dev
 region: us-east-1
 context:
@@ -9,10 +8,10 @@ context:
   # was created in another cloudformation
   routing:
     is_public: false
-    certificate: arn:aws:acm:us-east-1:566093341066:certificate/adf4c1f6-1a81-49b2-aa9c-7e84b0da5eb3
+    certificate: arn:aws:acm:us-east-1:912288704264:certificate/c1ff8358-9b24-4e68-9d38-28caf63c0fde
     dns:
-      zone_apex: elections.aws.wapo.pub.
-      domain: muckrock-dev.elections.aws.wapo.pub.
+      zone_apex: news-engineering.aws.wapo.pub.
+      domain: muckrock-dev.news-engineering.aws.wapo.pub.
   # # Required if using `import_listener`
   # priority: 0
 
@@ -97,4 +96,4 @@ context:
 
 params:
   # define the cluster name to run the service on
-  ClusterName: newsroom-dev
+  ClusterName: muckrock-dev

--- a/cfn/configs/prod/us-east-1/config.yml
+++ b/cfn/configs/prod/us-east-1/config.yml
@@ -83,4 +83,4 @@ context:
 params:
 
   # define the cluster name to run the service on
-  ClusterName: example-prod
+  ClusterName: muckrock-prod

--- a/cfn/configs/prod/us-east-1/config.yml
+++ b/cfn/configs/prod/us-east-1/config.yml
@@ -83,4 +83,4 @@ context:
 params:
 
   # define the cluster name to run the service on
-  ClusterName: muckrock-prod
+  ClusterName: foia-prod

--- a/cfn/templates/ecs-service.template.yml
+++ b/cfn/templates/ecs-service.template.yml
@@ -106,43 +106,43 @@ Parameters:
     PostgresHost:
         Description: Host of RDS postgres database
         Type: 'AWS::SSM::Parameter::Value<String>'
-        Default: /muckrock/{{ environment }}/POSTGRES_HOST
+        Default: /news-engineering/muckrock/{{ environment }}/POSTGRES_HOST
     
     PostgresUser:
         Description: User for RDS postgres database
         Type: 'AWS::SSM::Parameter::Value<String>'
-        Default: /muckrock/{{ environment }}/POSTGRES_USER
+        Default: /news-engineering/muckrock/{{ environment }}/POSTGRES_USER
     
     PostgresPassword:
         Description: Password for RDS postgres database
         Type: 'AWS::SSM::Parameter::Value<String>'
-        Default: /muckrock/{{ environment }}/POSTGRES_PASSWORD
+        Default: /news-engineering/muckrock/{{ environment }}/POSTGRES_PASSWORD
     
     PostgresDb:
         Description: Password of RDS postgres database
         Type: 'AWS::SSM::Parameter::Value<String>'
-        Default: /muckrock/{{ environment }}/POSTGRES_DB
+        Default: /news-engineering/muckrock/{{ environment }}/POSTGRES_DB
     
     RedisUrl:
         Description: URL for redis on elasticache
         Type: 'AWS::SSM::Parameter::Value<String>'
-        Default: /muckrock/{{ environment }}/REDIS_URL
+        Default: /news-engineering/muckrock/{{ environment }}/REDIS_URL
     
     SecretKey:
         Description: Django secret key
         Type: 'AWS::SSM::Parameter::Value<String>'
-        Default: /muckrock/{{ environment }}/SECRET_KEY
+        Default: /news-engineering/muckrock/{{ environment }}/SECRET_KEY
 
     # TODO remove and replace these with IAM policy
     AwsAccessKeyId:
         Description: Cred for accessint s3 bucket as user
         Type: 'AWS::SSM::Parameter::Value<String>'
-        Default: /muckrock/{{ environment }}/AWS_ACCESS_KEY_ID
+        Default: /news-engineering/muckrock/{{ environment }}/AWS_ACCESS_KEY_ID
 
     AwsSecretAccessKey:
         Description: Cred for accessint s3 bucket as user
         Type: 'AWS::SSM::Parameter::Value<String>'
-        Default: /muckrock/{{ environment }}/AWS_SECRET_ACCESS_KEY
+        Default: /news-engineering/muckrock/{{ environment }}/AWS_SECRET_ACCESS_KEY
 
     {% if container.image is defined or service.image is defined -%}
     ImageVersion:

--- a/compose/dev/django/nginx.conf
+++ b/compose/dev/django/nginx.conf
@@ -9,11 +9,8 @@ events {
 }
 
 http {
-  # this is docker-compose's dns resolver
-  # resolver 127.0.0.11;
   upstream app {
 		server muckrock_django:5000;
-    # server unix:/tmp/nginx.socket fail_timeout=0;
   }
 
   server {

--- a/compose/dev/django/start
+++ b/compose/dev/django/start
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -o errexit
-# set -o pipefail
-set -o nounset
-python /app/manage.py collectstatic --noinput
-/usr/local/bin/gunicorn -c file:config/gunicorn.conf.py muckrock.wsgi:application

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   #&& apt-get install openblas-dev gfortran g++ \
   # memcahced
   libmemcached-dev
-  # for imagediet
-  #&& apt-get install libmagic
+# for imagediet
+#&& apt-get install libmagic
 
 # heroku cli
 RUN curl https://cli-assets.heroku.com/install.sh | sh
@@ -35,10 +35,10 @@ ENV NODE_VERSION 5.6.0
 
 RUN mkdir $NVM_DIR
 RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash \
-    && . $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && nvm alias default $NODE_VERSION \
-    && nvm use default
+  && . $NVM_DIR/nvm.sh \
+  && nvm install $NODE_VERSION \
+  && nvm alias default $NODE_VERSION \
+  && nvm use default
 
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
@@ -48,7 +48,7 @@ COPY ./pip /pip
 RUN --mount=type=cache,target=/root/.cache/pip pip install -r /pip/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip pip install -r /pip/dev-requirements.txt
 
-COPY ./compose/production/django/entrypoint /entrypoint
+COPY ./compose/local/django/entrypoint /entrypoint
 RUN sed -i 's/\r//' /entrypoint
 RUN chmod +x /entrypoint
 

--- a/compose/local/django/entrypoint
+++ b/compose/local/django/entrypoint
@@ -12,7 +12,7 @@ if [ -z "${POSTGRES_USER}" ]; then
     export POSTGRES_USER="${base_postgres_image_default_user}"
 fi
 export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
-export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE}"
+export DJANGO_SETTINGS_MODULE="muckrock.settings.staging"
 
 postgres_ready() {
     python <<END
@@ -41,6 +41,3 @@ done
 echo >&2 'PostgreSQL is available'
 
 exec "$@"
-
-python /app/manage.py collectstatic --noinput
-gunicorn -c file:config/gunicorn.conf.py muckrock.wsgi:application

--- a/local.yml
+++ b/local.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 
 volumes:
   postgres_data_local: {}
@@ -22,6 +22,8 @@ services:
       - ./.envs/.local/.django
       - ./.envs/.local/.postgres
     command: /start
+    ports:
+      - 80:80
     networks:
       default:
         aliases:
@@ -60,7 +62,8 @@ services:
         aliases: []
       squarelet_default:
         aliases: []
-
+    ports:
+      - 8001:8001 # this is dumb, just needs a dummy port that is different than 80 since it inherits the django properties
   muckrock_celerybeat:
     <<: *django
     image: muckrock_local_celerybeat
@@ -73,7 +76,8 @@ services:
         aliases: []
       squarelet_default:
         aliases: []
-
+    ports:
+      - 8002:8002
 networks:
   squarelet_default:
     external: true


### PR DESCRIPTION
A few updates were needed to move this to the new account
* New namespacing pattern for SSM parameters
* New cluster (still creating, but will be called muckrock-dev/prod
* New domain/cert

I also had to tweak a lot of things as I was trying to deploy muckrock. This goes back and ensures that the local docker-compose files work and point to all the correct things, ie things in the `/compose/local/` namespace. 

It also doesn't hardcode the settings file to use, instead using an env variable `DJANGO_SETTINGS_MODULE`