### PR TITLE
Add celery container healthchecks

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -90,9 +90,10 @@ context:
     - name: muckrock_celerybeat
       image: muckrock_celerybeat
       essential: false
+      port: 5001
       cfn_properties:
         HealthCheck:
-          Command: ["CMD-SHELL", "curl -f http://127.0.0.1:5000/watchman || exit 1"]
+          Command: ["CMD-SHELL", "curl -f http://127.0.0.1:5001/watchman || exit 1"]
           Timeout: 20
       environment:
         DJANGO_SETTINGS_MODULE: muckrock.settings.staging
@@ -100,9 +101,10 @@ context:
     - name: muckrock_celeryworker
       image: muckrock_celeryworker
       essential: false
+      port: 5002
       cfn_properties:
         HealthCheck:
-          Command: ["CMD-SHELL", "curl -f http://127.0.0.1:5000/watchman || exit 1"]
+          Command: ["CMD-SHELL", "curl -f http://127.0.0.1:5002/watchman || exit 1"]
           Timeout: 20
       environment:
         DJANGO_SETTINGS_MODULE: muckrock.settings.staging

--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -90,12 +90,20 @@ context:
     - name: muckrock_celerybeat
       image: muckrock_celerybeat
       essential: false
+      cfn_properties:
+        HealthCheck:
+          Command: ["CMD-SHELL", "curl -f http://127.0.0.1:5000/watchman || exit 1"]
+          Timeout: 20
       environment:
         DJANGO_SETTINGS_MODULE: muckrock.settings.staging
         ALLOWED_HOSTS: "*"
     - name: muckrock_celeryworker
       image: muckrock_celeryworker
       essential: false
+      cfn_properties:
+        HealthCheck:
+          Command: ["CMD-SHELL", "curl -f http://127.0.0.1:5000/watchman || exit 1"]
+          Timeout: 20
       environment:
         DJANGO_SETTINGS_MODULE: muckrock.settings.staging
         ALLOWED_HOSTS: "*"

--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -90,22 +90,12 @@ context:
     - name: muckrock_celerybeat
       image: muckrock_celerybeat
       essential: false
-      port: 5001
-      cfn_properties:
-        HealthCheck:
-          Command: ["CMD-SHELL", "curl -f http://127.0.0.1:5001/watchman || exit 1"]
-          Timeout: 20
       environment:
         DJANGO_SETTINGS_MODULE: muckrock.settings.staging
         ALLOWED_HOSTS: "*"
     - name: muckrock_celeryworker
       image: muckrock_celeryworker
       essential: false
-      port: 5002
-      cfn_properties:
-        HealthCheck:
-          Command: ["CMD-SHELL", "curl -f http://127.0.0.1:5002/watchman || exit 1"]
-          Timeout: 20
       environment:
         DJANGO_SETTINGS_MODULE: muckrock.settings.staging
         ALLOWED_HOSTS: "*"

--- a/compose/dev/django/Dockerfile.celerybeat
+++ b/compose/dev/django/Dockerfile.celerybeat
@@ -58,4 +58,6 @@ WORKDIR /app
 RUN mv compose/$DEPLOYMENT_ENV/django/celery/beat/start entrypoint
 RUN chmod +x entrypoint
 
+EXPOSE 5000/tcp
+
 ENTRYPOINT ["/app/entrypoint"]

--- a/compose/dev/django/Dockerfile.celerybeat
+++ b/compose/dev/django/Dockerfile.celerybeat
@@ -58,6 +58,6 @@ WORKDIR /app
 RUN mv compose/$DEPLOYMENT_ENV/django/celery/beat/start entrypoint
 RUN chmod +x entrypoint
 
-EXPOSE 5000/tcp
+EXPOSE 5001/tcp
 
 ENTRYPOINT ["/app/entrypoint"]

--- a/compose/dev/django/Dockerfile.celerybeat
+++ b/compose/dev/django/Dockerfile.celerybeat
@@ -58,6 +58,7 @@ WORKDIR /app
 RUN mv compose/$DEPLOYMENT_ENV/django/celery/beat/start entrypoint
 RUN chmod +x entrypoint
 
-EXPOSE 5001/tcp
+HEALTHCHECK --interval=1m --timeout=5s \
+	CMD celery inspect ping -A muckrock.core.celery || exit 1
 
 ENTRYPOINT ["/app/entrypoint"]

--- a/compose/dev/django/Dockerfile.celeryworker
+++ b/compose/dev/django/Dockerfile.celeryworker
@@ -58,6 +58,7 @@ WORKDIR /app
 RUN mv compose/$DEPLOYMENT_ENV/django/celery/worker/start entrypoint
 RUN chmod +x entrypoint
 
-EXPOSE 5002/tcp
+HEALTHCHECK --interval=1m --timeout=5s \
+	CMD celery inspect ping -A muckrock.core.celery || exit 1
 
 ENTRYPOINT ["/app/entrypoint"]

--- a/compose/dev/django/Dockerfile.celeryworker
+++ b/compose/dev/django/Dockerfile.celeryworker
@@ -58,6 +58,6 @@ WORKDIR /app
 RUN mv compose/$DEPLOYMENT_ENV/django/celery/worker/start entrypoint
 RUN chmod +x entrypoint
 
-EXPOSE 5000/tcp
+EXPOSE 5002/tcp
 
 ENTRYPOINT ["/app/entrypoint"]

--- a/compose/dev/django/Dockerfile.celeryworker
+++ b/compose/dev/django/Dockerfile.celeryworker
@@ -58,4 +58,6 @@ WORKDIR /app
 RUN mv compose/$DEPLOYMENT_ENV/django/celery/worker/start entrypoint
 RUN chmod +x entrypoint
 
+EXPOSE 5000/tcp
+
 ENTRYPOINT ["/app/entrypoint"]


### PR DESCRIPTION
The deploy is still not completing because the celery containers don't have a healthcheck. I tested this locally by running these `CMD` declarations inside the celery containers, they both respond with a `pong`, so I think this should work since ECS will use docker's own healthchecks by default. 