### PR TITLE
Move Celery Healthchecks to ECS-agent level

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -90,12 +90,18 @@ context:
     - name: muckrock_celerybeat
       image: muckrock_celerybeat
       essential: false
+      cfn_properties:
+        HealthCheck:
+          Command: ["CMD-SHELL", "celery inspect ping -A muckrock.core.celery || exit 1"]
       environment:
         DJANGO_SETTINGS_MODULE: muckrock.settings.staging
         ALLOWED_HOSTS: "*"
     - name: muckrock_celeryworker
       image: muckrock_celeryworker
       essential: false
+      cfn_properties:
+        HealthCheck:
+          Command: ["CMD-SHELL", "celery inspect ping -A muckrock.core.celery || exit 1"]
       environment:
         DJANGO_SETTINGS_MODULE: muckrock.settings.staging
         ALLOWED_HOSTS: "*"

--- a/compose/dev/django/Dockerfile.celerybeat
+++ b/compose/dev/django/Dockerfile.celerybeat
@@ -58,7 +58,4 @@ WORKDIR /app
 RUN mv compose/$DEPLOYMENT_ENV/django/celery/beat/start entrypoint
 RUN chmod +x entrypoint
 
-HEALTHCHECK --interval=1m --timeout=5s \
-	CMD celery inspect ping -A muckrock.core.celery || exit 1
-
 ENTRYPOINT ["/app/entrypoint"]

--- a/compose/dev/django/Dockerfile.celeryworker
+++ b/compose/dev/django/Dockerfile.celeryworker
@@ -58,7 +58,4 @@ WORKDIR /app
 RUN mv compose/$DEPLOYMENT_ENV/django/celery/worker/start entrypoint
 RUN chmod +x entrypoint
 
-HEALTHCHECK --interval=1m --timeout=5s \
-	CMD celery inspect ping -A muckrock.core.celery || exit 1
-
 ENTRYPOINT ["/app/entrypoint"]

--- a/local.yml
+++ b/local.yml
@@ -33,6 +33,8 @@ services:
         aliases:
           - dev.muckrock.com
           - dev.foiamachine.org
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://127.0.0.1:80/watchman || exit 1"]
 
   muckrock_postgres:
     build:
@@ -64,6 +66,8 @@ services:
         aliases: []
     ports:
       - 8001:8001 # this is dumb, just needs a dummy port that is different than 80 since it inherits the django properties
+    healthcheck:
+      test: celery inspect ping -A muckrock.core.celery || exit 1
   muckrock_celerybeat:
     <<: *django
     image: muckrock_local_celerybeat
@@ -78,6 +82,8 @@ services:
         aliases: []
     ports:
       - 8002:8002
+    healthcheck: 
+      test: celery inspect ping -A muckrock.core.celery || exit 1
 networks:
   squarelet_default:
     external: true


### PR DESCRIPTION
I had the celery healthchecks in the dockerfile but they weren't getting picked up by ECS and used.The nginx and django healthchecks are working in ECS, and they were defined in the cloudformation config, so I added the celery ones there as well. I also added them to the docker-compose file locally so I can do

<img width="784" alt="Screen Shot 2021-03-31 at 11 00 51 AM" src="https://user-images.githubusercontent.com/6980388/113166005-5d74cd80-9210-11eb-9e8e-678e1bd3afd7.png">

And verify their health