### PR TITLE
Update DB credentials

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -82,6 +82,7 @@ context:
           Timeout: 20
       environment:
         AWS_STORAGE_BUCKET_NAME: wapo-muckrock-dev
+        POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         DJANGO_SETTINGS_MODULE: muckrock.settings.staging
         ALLOWED_HOSTS: "*"

--- a/cfn/templates/ecs-service.template.yml
+++ b/cfn/templates/ecs-service.template.yml
@@ -60,14 +60,16 @@ LogConfiguration:
 {% endif -%}
 {% if container.environment is defined %}
 Environment:
-  - Name: POSTGRES_HOST
-    Value: !Sub ${PostgresHost}
-  - Name: POSTGRES_DB
-    Value: !Sub ${PostgresDb}
   - Name: POSTGRES_USER
-    Value: !Sub ${PostgresUser}
+    {% raw %}Value: '{{resolve:secretsmanager:/newsroom-apps/aurora-postgresql-{% endraw %}{{ environment }}{% raw %}/app:SecretString:username}}'{% endraw %}
+
   - Name: POSTGRES_PASSWORD
-    Value: !Sub ${PostgresPassword}
+    {% raw %}Value: '{{resolve:secretsmanager:/newsroom-apps/aurora-postgresql-{% endraw %}{{ environment }}{% raw %}/app:SecretString:password}}'{% endraw %}
+
+  - Name: POSTGRES_HOST
+    Value:
+      Fn::ImportValue: !Sub 'newsroom-apps-{{ environment }}-writer-host'
+
   - Name: REDIS_URL
     Value: !Sub ${RedisUrl}
   - Name: SECRET_KEY
@@ -125,11 +127,6 @@ Parameters:
         Description: Password for RDS postgres database
         Type: 'AWS::SSM::Parameter::Value<String>'
         Default: /news-engineering/muckrock/{{ environment }}/POSTGRES_PASSWORD
-    
-    PostgresDb:
-        Description: Password of RDS postgres database
-        Type: 'AWS::SSM::Parameter::Value<String>'
-        Default: /news-engineering/muckrock/{{ environment }}/POSTGRES_DB
     
     RedisUrl:
         Description: URL for redis on elasticache


### PR DESCRIPTION
Databases were switched around this week which broke the muckrock app. This adds the same `secretsmanager` get commands used in the capitol arrests admin to fetch DB creds programatically. I tested the DB connection locally and it worked. 