### PR TITLE
Use correct docker entrypoints locally

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -52,18 +52,6 @@ COPY ./compose/local/django/entrypoint /entrypoint
 RUN sed -i 's/\r//' /entrypoint
 RUN chmod +x /entrypoint
 
-COPY ./compose/local/django/start /start
-RUN sed -i 's/\r//' /start
-RUN chmod +x /start
-
-COPY ./compose/local/django/celery/worker/start /start-celeryworker
-RUN sed -i 's/\r//' /start-celeryworker
-RUN chmod +x /start-celeryworker
-
-COPY ./compose/local/django/celery/beat/start /start-celerybeat
-RUN sed -i 's/\r//' /start-celerybeat
-RUN chmod +x /start-celerybeat
-
 WORKDIR /app
 
 ENTRYPOINT ["/entrypoint"]

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.8
 
 ENV PYTHONUNBUFFERED 1
 
+ARG MIGRATE
+ENV MIGRATE $MIGRATE
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
   # psycopg2 dependencies
   #&& apt-get install build-deps gcc python2-dev musl-dev \

--- a/compose/local/django/celery/beat/start
+++ b/compose/local/django/celery/beat/start
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -o errexit
-set -o nounset
-
-
-rm -f './celerybeat.pid'
-celery -A muckrock.core.celery beat -l DEBUG

--- a/compose/local/django/celery/worker/start
+++ b/compose/local/django/celery/worker/start
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -o errexit
-set -o nounset
-
-
-celery -A muckrock.core.celery worker -Q celery,phaxio -l DEBUG

--- a/compose/local/django/entrypoint
+++ b/compose/local/django/entrypoint
@@ -40,4 +40,12 @@ until postgres_ready; do
 done
 echo >&2 'PostgreSQL is available'
 
+python manage.py migrate
+
+# clean up celery if pid exists
+if test -f './celerybeat.pid'; then
+	echo "cleaning up existing celery pid"
+	rm -f './celerybeat.pid'
+fi
+
 exec "$@"

--- a/compose/local/django/entrypoint
+++ b/compose/local/django/entrypoint
@@ -40,7 +40,9 @@ until postgres_ready; do
 done
 echo >&2 'PostgreSQL is available'
 
-python manage.py migrate
+if [ -n "${MIGRATE}" ]; then 
+	python manage.py migrate
+fi
 
 # clean up celery if pid exists
 if test -f './celerybeat.pid'; then

--- a/compose/local/django/start
+++ b/compose/local/django/start
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -o errexit
-set -o pipefail
-set -o nounset
-
-
-python manage.py migrate
-python manage.py runserver 0.0.0.0:80

--- a/local.yml
+++ b/local.yml
@@ -21,7 +21,7 @@ services:
     env_file:
       - ./.envs/.local/.django
       - ./.envs/.local/.postgres
-    command: /start
+    command: ["python", "manage.py", "runserver", "0.0.0.0:80"]
     ports:
       - 80:80
     networks:
@@ -56,7 +56,7 @@ services:
     depends_on:
       - muckrock_redis
       - muckrock_postgres
-    command: /start-celeryworker
+    command: ["celery", "-A", "muckrock.core.celery", "worker", "-l", "INFO"]
     environment:
       - C_FORCE_ROOT=true
     networks:
@@ -74,7 +74,7 @@ services:
     depends_on:
       - muckrock_redis
       - muckrock_postgres
-    command: /start-celerybeat
+    command: ["celery", "-A", "muckrock.core.celery", "beat", "-l", "INFO"]
     networks:
       default:
         aliases: []

--- a/local.yml
+++ b/local.yml
@@ -18,6 +18,7 @@ services:
       - ~/.netrc:/root/.netrc
     environment:
       - IPYTHONDIR=/app/.ipython
+      # - MIGRATE=true
     env_file:
       - ./.envs/.local/.django
       - ./.envs/.local/.postgres


### PR DESCRIPTION
On ECS, I noticed that containers were not exiting when a new deploy started, or when a healthcheck failed and the ecs-agent needed to respawn a task. This was because all of the entrypoints (django, celery) were started as child processes of shell scripts. 

When the ECS agent manages tasks, it sends a `SIGTERM` signal to the container, and only PID 1 will respond to this. Because the python entrypoints were written as child commands, they didn't have PID 1, and therefore didn't stop when sent the signal. (more here: https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/). They correct way to address this is to run the entrypoint in exec form (as an array). 

I updated the docker-compose file to achieve this locally and tested by sending each container a `SIGTERM` signal and confirmed that it exited. (I had always been killing them before with ctrl+C which is a harsher `SIGKILL` and will always work. 

I also realized we shouldn't be running a migration every time docker-compose starts, so I set an environment variable `MIGRATE` that determines if a migration is run in the docker entrypoint. 

### Testing
`docker ps` (grab container id)
`docker kill --signal="SIGTERM" <container-id>`
in `local.yml` uncomment the line in the django container `MIGRATE=true` and it should run a migration on startup (only in the django container). 

There will be a subsequent PR to add this to the dev stage (and prod eventually) but I wanted to do it in discrete stages to test. 

Note: one thing that still irks me is that the ECS agent is supposed to send a `SIGKILL` after a failed `SIGTERM` to eventually kill the container, but this didn't seem to be affecting them either. I don't have an answer to this, but I figured that properly exiting from a `SIGTERM` would solve the issue.  