### PR TITLE
Forgot to still copy shell script into docker container before running it

### DIFF
--- a/compose/dev/django/Dockerfile.django
+++ b/compose/dev/django/Dockerfile.django
@@ -81,5 +81,8 @@ RUN npm run build
 RUN pip install -r pip/requirements.txt
 WORKDIR /app
 
+RUN mv compose/$DEPLOYMENT_ENV/django/entrypoint entrypoint
+RUN chmod +x entrypoint
+
 EXPOSE 5000/tcp
 ENTRYPOINT ["/app/entrypoint"]


### PR DESCRIPTION
Adding part of the dockerfile back in from before, it was trying to run an entrypoint that wasn't there. 