### PR TITLE
add silk middleware to staging

### DIFF
--- a/muckrock/settings/staging.py
+++ b/muckrock/settings/staging.py
@@ -13,7 +13,7 @@ from django_mailgun import MailgunBackend
 # MuckRock
 from muckrock.settings.heroku import *
 
-INSTALLED_APPS += ("bandit",)
+INSTALLED_APPS += ("bandit","silk",)
 
 BANDIT_EMAIL = os.environ.get("BANDIT_EMAIL", "staging@muckrock.com")
 BANDIT_WHITELIST = [
@@ -41,3 +41,5 @@ os.environ["https_proxy"] = os.environ.get("FIXIE_URL", "")
 SCOUT_NAME = "MuckRock Staging"
 
 DEBUG = True
+
+MIDDLEWARE = ("silk.middleware.SilkyMiddleware",) + MIDDLEWARE


### PR DESCRIPTION
```
RuntimeError at /

Model class silk.models.Request doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```