### PR TITLE
Add a redis cache config for django

### DIFF
--- a/compose/local/django/entrypoint
+++ b/compose/local/django/entrypoint
@@ -12,7 +12,6 @@ if [ -z "${POSTGRES_USER}" ]; then
     export POSTGRES_USER="${base_postgres_image_default_user}"
 fi
 export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
-export DJANGO_SETTINGS_MODULE="muckrock.settings.staging"
 
 postgres_ready() {
     python <<END

--- a/muckrock/settings/base.py
+++ b/muckrock/settings/base.py
@@ -574,7 +574,8 @@ DASHING = {
     "PERMISSION_CLASSES": ("dashing.permissions.IsAdminUser",),
 }
 
-CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
+CONSTANCE_BACKEND = "constance.backends.database.RedisBackend"
+CONSTANCE_REDIS_CONNECTION = os.environ.get("REDIS_URL")
 CONSTANCE_SUPERUSER_ONLY = False
 CONSTANCE_CONFIG = OrderedDict(
     [


### PR DESCRIPTION
Muckrock uses https://django-constance.readthedocs.io/en/latest/backends.html for its backend cache configuration, so I modified our settings to use redis as a backend instead of a default django one. I just followed the configuration steps in their docs and it seemed to connect fine to local redis, but will be curious to test in dev as well. I verified the elasticache connection string locally and it accepted connections fine. 