### PR TITLE
add logging and store task state in celery

### DIFF
--- a/muckrock/foia/tasks.py
+++ b/muckrock/foia/tasks.py
@@ -346,7 +346,6 @@ def composer_create_foias(composer_pk, contact_info, **kwargs):
 
 
 @task(
-    ignore_result=True,
     max_retries=10,
     name="muckrock.foia.tasks.composer_delayed_submit",
 )
@@ -354,7 +353,7 @@ def composer_delayed_submit(composer_pk, approve, contact_info, **kwargs):
     """Submit a composer to all agencies"""
     # pylint: disable=unused-argument
     logger.info(
-        "Starting composer_delayed_submit: (%s, %s, %s, %s)",
+        "Starting a composer_delayed_submit: (%s, %s, %s, %s)",
         composer_pk,
         approve,
         contact_info,
@@ -362,6 +361,7 @@ def composer_delayed_submit(composer_pk, approve, contact_info, **kwargs):
     )
     try:
         composer = FOIAComposer.objects.get(pk=composer_pk)
+        logger.info("FOIAComposer: %s", composer)
     except FOIAComposer.DoesNotExist:
         # If the composer was deleted, just return
         logger.info("could not fetch composer %s from db", composer_pk)


### PR DESCRIPTION
We are trying to figure out the delayed_submit task is silently failing, tweaking a few things including removing https://docs.celeryproject.org/en/stable/reference/celery.app.task.html#celery.app.task.Task.ignore_result from the task