### PR TITLE
NE-223 (pt 2): Use v4 pre-signed S3 uploads

### DIFF
--- a/muckrock/assets/js/muckrock.js
+++ b/muckrock/assets/js/muckrock.js
@@ -41,7 +41,7 @@ import './stripe';
 import './tabs';
 import './task';
 
-import qq from 'fine-uploader/lib/s3';
+import qq from 'fine-uploader';
 window.qq = qq;
 
 import 'jquery.tabulator';

--- a/muckrock/fine_uploader/urls.py
+++ b/muckrock/fine_uploader/urls.py
@@ -9,7 +9,6 @@ from django.conf.urls import url
 from muckrock.fine_uploader import views
 
 urlpatterns = [
-    url(r"^sign/$", views.sign, name="fine-uploader-sign"),
     url(r"^blank/$", views.blank, name="fine-uploader-blank"),
     url(
         r"^success_request/$",
@@ -23,19 +22,19 @@ urlpatterns = [
     ),
     url(r"^success_comm/$", views.success_comm, name="fine-uploader-success-comm"),
     url(
-        r"^key_request/$", views.key_name_request, name="fine-uploader-key-name-request"
+        r"^preupload_request/$", views.preupload_request, name="fine-uploader-preupload-request"
     ),
     url(
-        r"^key_composer/$",
-        views.key_name_composer,
-        name="fine-uploader-key-name-composer",
+        r"^preupload_composer/$",
+        views.preupload_composer,
+        name="fine-uploader-preupload-composer",
     ),
-    url(r"^key_comm/$", views.key_name_comm, name="fine-uploader-key-name-comm"),
+    url(r"^preupload_comm/$", views.preupload_comm, name="fine-uploader-preupload-comm"),
     url(
-        r"^delete_request/$", views.delete_request, name="fine-uploader-delete-request"
+        r"^delete_request/?(?P<idx>\d*)$", views.delete_request, name="fine-uploader-delete-request"
     ),
     url(
-        r"^delete_composer/$",
+        r"^delete_composer/?(?P<idx>\d*)$",
         views.delete_composer,
         name="fine-uploader-delete-composer",
     ),

--- a/muckrock/fine_uploader/views.py
+++ b/muckrock/fine_uploader/views.py
@@ -218,7 +218,7 @@ def _get_key(request, model, id_name=None):
     return default_storage.get_available_name(key)
 
 
-def _preupload(request, model, id_name):
+def _preupload(request, model, id_name=None):
     """Generates request info so the client can update directly to S3"""
     key = _get_key(request, model, id_name)
     contentType = request.POST.get("type")

--- a/muckrock/fine_uploader/views.py
+++ b/muckrock/fine_uploader/views.py
@@ -19,6 +19,9 @@ import hmac
 import json
 import os
 
+# Third Party
+import boto3
+
 # MuckRock
 from muckrock.foia.models import (
     FOIACommunication,
@@ -49,7 +52,8 @@ def _success(request, model, attachment_model, fk_name):
     attachment.ffile.name = request.POST["key"]
     attachment.save()
 
-    return HttpResponse()
+    # Send the client the ID to update its reference
+    return JsonResponse({ "id": attachment.id })
 
 
 @login_required
@@ -78,13 +82,13 @@ def success_comm(request):
     if len(request.POST["key"]) > 255:
         return HttpResponseBadRequest()
 
-    comm.attach_file(
+    attachment = comm.attach_file(
         path=request.POST["key"],
         name=os.path.basename(request.POST["key"]),
         source=request.user.profile.full_name,
     )
 
-    return HttpResponse()
+    return JsonResponse({ "id": attachment.id })
 
 
 def _session(request, model):
@@ -106,6 +110,7 @@ def _session(request, model):
                 "uuid": attm.pk,
                 "size": attm.ffile.size,
                 "s3Key": attm.ffile.name,
+                "s3Bucket": settings.AWS_STORAGE_BUCKET_NAME
             }
         )
     return JsonResponse(data, safe=False)
@@ -123,11 +128,11 @@ def session_composer(request):
     return _session(request, FOIAComposer)
 
 
-def _delete(request, model):
+def _delete(request, model, idx):
     """Delete a pending attachment"""
     try:
         attm = model.objects.get(
-            ffile=request.POST.get("key"), user=request.user, sent=False
+            pk=idx, user=request.user, sent=False
         )
     except model.DoesNotExist:
         return HttpResponseBadRequest()
@@ -140,76 +145,49 @@ def _delete(request, model):
 
 
 @login_required
-def delete_request(request):
+def delete_request(request, idx):
     """Delete a pending attachment from a FOIA Request"""
-    return _delete(request, OutboundRequestAttachment)
+    return _delete(request, OutboundRequestAttachment, idx)
 
 
 @login_required
-def delete_composer(request):
+def delete_composer(request, idx):
     """Delete a pending attachment from a FOIA Composer"""
-    return _delete(request, OutboundComposerAttachment)
+    return _delete(request, OutboundComposerAttachment, idx)
 
 
-@login_required
-def sign(request):
-    """Sign the data to upload to S3"""
-    payload = json.loads(request.body)
-    if "headers" in payload:
-        return JsonResponse(_sign_headers(payload["headers"]))
-    elif _is_valid_policy(request.user, payload):
-        return JsonResponse(_sign_policy_document(payload))
-    else:
-        return JsonResponse({"invalid": True}, status=400)
+def _build_presigned_url(key, user=None):
+    """Generate a policy document and presigned URL for an upload
+    https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-presigned-urls.html#generating-a-presigned-url-to-upload-a-file"""
+    
+    bucket = settings.AWS_STORAGE_BUCKET_NAME
+    conditions = [
+        # Restrict uploads to specific bucket/key/ACL
+        {"acl": settings.AWS_DEFAULT_ACL},
+        {"bucket": bucket},
+        {"key": key},
+        {"success_action_status": "200"},
+        # Make sure the MIME type is valid
 
+        # Whitelist metadata headers
+        ["starts-with", "$x-amz-meta-qqfilename", ""],
+        ["starts-with", "$x-amz-meta-qquuid", ""],
+        ["starts-with", "$x-amz-meta-qqtotalfilesize", ""],
+    ]
 
-def _is_valid_policy(user, policy_document):
-    """
-    Verify the policy document has not been tampered with client-side
-    before sending it off.
-    """
-    bucket = None
-    parsed_max_size = None
-
-    if user.has_perm("foia.unlimited_attachment_size"):
-        max_size = None
-    else:
-        max_size = settings.MAX_ATTACHMENT_SIZE
-
-    for condition in policy_document["conditions"]:
-        if isinstance(condition, list) and condition[0] == "content-length-range":
-            parsed_max_size = int(condition[2])
-        elif "bucket" in condition:
-            bucket = condition["bucket"]
-
-    return bucket == settings.AWS_STORAGE_BUCKET_NAME and parsed_max_size == max_size
-
-
-def _sign_policy_document(policy_document):
-    """Sign and return the policy doucument for a simple upload.
-    http://aws.amazon.com/articles/1434/#signyours3postform"""
-    # TODO refactor into IAM
-    policy = base64.b64encode(json.dumps(policy_document).encode("utf8"))
-    signature = base64.b64encode(
-        hmac.new(
-            settings.AWS_SECRET_ACCESS_KEY.encode("utf8"), policy, hashlib.sha1
-        ).digest()
+    if not user or not user.has_perm("foia.unlimited_attachment_size"):
+        conditions.append(["content-length-range","0", settings.MAX_ATTACHMENT_SIZE])
+    
+    s3 = boto3.client("s3")
+    url_data = s3.generate_presigned_post(bucket, key,
+        Conditions=conditions,
+        ExpiresIn=60
     )
-    return {"policy": policy.decode("utf8"), "signature": signature.decode("utf8")}
 
+    url_data["fields"]["acl"] = settings.AWS_DEFAULT_ACL
+    url_data["fields"]["success_action_status"] = 200
 
-def _sign_headers(headers):
-    """Sign and return the headers for a chunked upload"""
-    # TODO refactor into IAM
-    return {
-        "signature": base64.b64encode(
-            hmac.new(
-                settings.AWS_SECRET_ACCESS_KEY.encode("utf8"),
-                headers.encode("utf8"),
-                hashlib.sha1,
-            ).digest()
-        ).decode("utf8")
-    }
+    return url_data
 
 
 def _key_name_trim(name):
@@ -229,38 +207,39 @@ def _key_name_trim(name):
     return name
 
 
-def _key_name(request, model, id_name):
-    """Generate the S3 key name from the filename"""
+def _get_key(request, model, id_name=None):
+    """Generate the S3 key name from the filename, while guaranteeing uniqueness"""
     name = request.POST.get("name")
     attached_id = request.POST.get("id")
     name = _key_name_trim(name)
-    attachment = model(user=request.user, **{id_name: attached_id})
+    attachment = model(user=request.user, **{id_name: attached_id}) if id_name else model()
     key = attachment.ffile.field.generate_filename(attachment.ffile.instance, name)
-    key = default_storage.get_available_name(key)
-    return JsonResponse({"key": key})
+    return default_storage.get_available_name(key)
+
+
+def _preupload(request, model, id_name):
+    """Generates request info so the client can update directly to S3"""
+    key = _get_key(request, model, id_name)
+    presigned_url = _build_presigned_url(key, user=request.user)
+    return JsonResponse(presigned_url)
 
 
 @login_required
-def key_name_request(request):
-    """Generate the S3 key name for a FOIA Request"""
-    return _key_name(request, OutboundRequestAttachment, "foia_id")
+def preupload_request(request):
+    """Generate upload info for a FOIA Request"""
+    return _preupload(request, OutboundRequestAttachment, "foia_id")
 
 
 @login_required
-def key_name_composer(request):
-    """Generate the S3 key name for a FOIA Composer"""
-    return _key_name(request, OutboundComposerAttachment, "composer_id")
+def preupload_composer(request):
+    """Generate upload info for a FOIA Composer"""
+    return _preupload(request, OutboundComposerAttachment, "composer_id")
 
 
 @login_required
-def key_name_comm(request):
-    """Generate the S3 key name from the filename"""
-    name = request.POST.get("name")
-    name = _key_name_trim(name)
-    file_ = FOIAFile()
-    key = file_.ffile.field.generate_filename(file_.ffile.instance, name)
-    key = default_storage.get_available_name(key)
-    return JsonResponse({"key": key})
+def preupload_comm(request):
+    """Generate upload info for a communication"""
+    return _preupload(request, FOIAFile)
 
 
 @login_required

--- a/muckrock/fine_uploader/views.py
+++ b/muckrock/fine_uploader/views.py
@@ -3,6 +3,7 @@
 # Django
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ValidationError
 from django.core.files.storage import default_storage
 from django.http import (
     HttpResponse,
@@ -13,10 +14,6 @@ from django.http import (
 from django.utils import timezone
 
 # Standard Library
-import base64
-import hashlib
-import hmac
-import json
 import os
 
 # Third Party
@@ -156,10 +153,14 @@ def delete_composer(request, idx):
     return _delete(request, OutboundComposerAttachment, idx)
 
 
-def _build_presigned_url(key, user=None):
+def _build_presigned_url(key, contentType, user=None):
     """Generate a policy document and presigned URL for an upload
     https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-presigned-urls.html#generating-a-presigned-url-to-upload-a-file"""
     
+    # Validate MIME type
+    if not contentType in settings.ALLOWED_FILE_MIMES:
+        raise ValidationError("Invalid file type")
+
     bucket = settings.AWS_STORAGE_BUCKET_NAME
     conditions = [
         # Restrict uploads to specific bucket/key/ACL
@@ -167,8 +168,7 @@ def _build_presigned_url(key, user=None):
         {"bucket": bucket},
         {"key": key},
         {"success_action_status": "200"},
-        # Make sure the MIME type is valid
-
+        {"Content-Type": contentType},
         # Whitelist metadata headers
         ["starts-with", "$x-amz-meta-qqfilename", ""],
         ["starts-with", "$x-amz-meta-qquuid", ""],
@@ -186,6 +186,7 @@ def _build_presigned_url(key, user=None):
 
     url_data["fields"]["acl"] = settings.AWS_DEFAULT_ACL
     url_data["fields"]["success_action_status"] = 200
+    url_data["fields"]["Content-Type"] = contentType
 
     return url_data
 
@@ -220,7 +221,13 @@ def _get_key(request, model, id_name=None):
 def _preupload(request, model, id_name):
     """Generates request info so the client can update directly to S3"""
     key = _get_key(request, model, id_name)
-    presigned_url = _build_presigned_url(key, user=request.user)
+    contentType = request.POST.get("type")
+
+    try:
+        presigned_url = _build_presigned_url(key, contentType, user=request.user)
+    except ValidationError as e:
+        return JsonResponse({ "error": e.message }, status=400)
+    
     return JsonResponse(presigned_url)
 
 

--- a/muckrock/templates/lib/component/fine-uploader.html
+++ b/muckrock/templates/lib/component/fine-uploader.html
@@ -138,10 +138,14 @@ function createCreateUploader(dataAttr, urls, spreadsheetsOnly) {
           $.ajax({
             type: 'POST',
             url: urls.pre,
-            data: { name: filename, id: pk },
+            data: { 
+              name: filename, 
+              id: pk,
+              type: uploader.getFile(id).type
+            },
             headers: { 'X-CSRFToken': '{{ csrf_token }}' }
           })
-          .fail(function() {promise.failure();})
+          .fail(function(data) { promise.failure(data); })
           .done(function(data) {
             // Overide upload endpoint and params with values from AWS signature
             uploader.setEndpoint(data.url, id);

--- a/muckrock/templates/lib/component/fine-uploader.html
+++ b/muckrock/templates/lib/component/fine-uploader.html
@@ -74,6 +74,9 @@ function createCreateUploader(dataAttr, urls, spreadsheetsOnly) {
     if (dataAttr) {
       pk = element.getAttribute(dataAttr);
     }
+
+    // Build client-side validation options based on user perms
+    // (Server validation is handled separately)
     {% has_perm 'foia.unlimited_attachment_size' request.user as unlimited_attachment %}
     {% if unlimited_attachment %}
       var limitAttachments = false;
@@ -108,37 +111,12 @@ function createCreateUploader(dataAttr, urls, spreadsheetsOnly) {
       template: 'qq-simple-thumbnails-template',
       validation: validation,
       request: {
-        endpoint: 'https://{{settings.AWS_STORAGE_BUCKET_NAME}}.s3.amazonaws.com',
-        accessKey: '{{settings.AWS_ACCESS_KEY_ID}}',
-      },
-      objectProperties: {
-        acl: 'public-read',
-        key: function(fileId) {
-          var keyRetrieval = new qq.Promise();
-          var filename = encodeURIComponent(uploader.getName(fileId));
-          $.post(
-            urls.key,
-            {name: filename, id: pk}
-          )
-            .done(function(data) {keyRetrieval.success(data.key);})
-            .fail(function() {keyRetrieval.failure();});
-          return keyRetrieval;
-        },
-      },
-      signature: {
-        endpoint: '{% url "fine-uploader-sign" %}',
-        customHeaders: {
-          'X-CSRFToken': '{{ csrf_token }}',
-        },
-      },
-      uploadSuccess: {
-        endpoint: urls.success,
-        customHeaders: {
-          'X-CSRFToken': '{{ csrf_token }}',
-        },
-        params: {
-          'id': pk,
-        },
+        inputName: 'file',
+        filenameParam: 'x-amz-meta-qqfilename',
+        uuidName: 'x-amz-meta-qquuid',
+        totalFileSizeName: 'x-amz-meta-qqtotalfilesize',
+        requireSuccessJson: false,
+        endpoint: null // will be set in onUpload handler
       },
       iframeSupport: {
         localBlankPagePath: '{% url "fine-uploader-blank" %}',
@@ -147,70 +125,109 @@ function createCreateUploader(dataAttr, urls, spreadsheetsOnly) {
         enableAuto: true,
       },
       chunking: {
-        enabled: true,
-        concurrent: {
-          enabled: true,
-        },
-        success: {
-          endpoint: urls.success,
-          customHeaders: {
-            'X-CSRFToken': '{{ csrf_token }}',
-          },
-          params: {
-            'id': pk,
-          },
-        }
+        enabled: false
       },
       resume: {
         enabled: true,
       },
+      callbacks: {
+        onUpload: function(id, filename){
+          var promise = new qq.Promise();
+
+          // Fetch S3 path and presigned URLs from the server
+          $.ajax({
+            type: 'POST',
+            url: urls.pre,
+            data: { name: filename, id: pk },
+            headers: { 'X-CSRFToken': '{{ csrf_token }}' }
+          })
+          .fail(function() {promise.failure();})
+          .done(function(data) {
+            // Overide upload endpoint and params with values from AWS signature
+            uploader.setEndpoint(data.url, id);
+            uploader.setParams(data.fields, id);
+            // Cache S3 key onComplete handler to use
+            uploader._s3FileKeys[id] = data.fields.key;
+            // Resolve with success so upload begins
+            promise.success();
+          });
+
+          return promise;
+        },
+        onComplete: function(id, filename, req){
+          var promise = new qq.Promise();
+
+          // Notify server on successful upload so it can create DB records
+          $.ajax({
+            type: 'POST',
+            url: urls.success,
+            data: { key: uploader._s3FileKeys[id], id: pk },
+            headers: { 'X-CSRFToken': '{{ csrf_token }}' }
+          })
+          .fail(function(){ promise.failure(); })
+          .done(function(created){ 
+            // Update internal uuid with id of new DB entry
+            uploader.setUuid(id, created.id);
+            promise.success();
+          });
+
+          return promise;
+        }
+      }
     };
+
     if (urls.session) {
       options['session'] = {
         endpoint: urls.session,
         params: {
           'id': pk,
         },
+        customHeaders: {
+          'X-CSRFToken': '{{ csrf_token }}',
+        },
       };
     }
+    
     if (urls.delete_) {
       options['deleteFile'] = {
         enabled: true,
-        method: 'POST',
+        method: 'DELETE',
         endpoint: urls.delete_,
         customHeaders: {
           'X-CSRFToken': '{{ csrf_token }}',
         },
       };
     }
-    const uploader = new qq.s3.FineUploader(options);
+    
+    var uploader = new qq.FineUploader(options);
+    uploader._s3FileKeys = {};
   };
 };
 
 var createUploaderRequest = createCreateUploader(
   'data-foia-pk',
   {
-    key: '{% url "fine-uploader-key-name-request" %}',
+    pre: '{% url "fine-uploader-preupload-request" %}',
     success: '{% url "fine-uploader-success-request" %}',
     session: '{% url "fine-uploader-session-request" %}',
-    delete_: '{% url "fine-uploader-delete-request" %}',
+    delete_: '{% url "fine-uploader-delete-request" "" %}',
   },
   false
   );
 var createUploaderComposer = createCreateUploader(
   'data-composer-pk',
   {
-    key: '{% url "fine-uploader-key-name-composer" %}',
+    pre: '{% url "fine-uploader-preupload-composer" %}',
     success: '{% url "fine-uploader-success-composer" %}',
     session: '{% url "fine-uploader-session-composer" %}',
-    delete_: '{% url "fine-uploader-delete-composer" %}',
+    delete_: '{% url "fine-uploader-delete-composer" "" %}',
   },
   false
   );
 var createUploaderComm = createCreateUploader(
   'data-comm-pk',
   {
-    key: '{% url "fine-uploader-key-name-comm" %}',
+    pre: '{% url "fine-uploader-preupload-comm" %}',
     success: '{% url "fine-uploader-success-comm" %}',
   },
   false


### PR DESCRIPTION
## Problem
When I started on #22, I quickly realized we'd need to refactor the uploading logic, for two reasons:
- First, we needed to move to AWS v4 signatures, because AWS has deprecated the older v2 policy signing algorithm and disabled it on new uploads (like ours)
- We also needed to adjust the behavior of the `fine-uploader` client to not hard-code the `accessKey` value, since we're now using role-based authentication with temporary, rotating access keys. The current implementation wouldn't work with our deployment setup, because there's no guarantee that the HTML template and the policy signature would come from the same container — so there was likely to be a mismatch between the access key on the client and the secret used to sign the policy.

## Solution
I poked around on the [fine-uploader documentation](https://docs.fineuploader.com) for a long time, but couldn't find an easy way to solve the second bullet above. I found a couple of [related issues](https://github.com/FineUploader/fine-uploader/issues/1647) on the library's GitHub repo, which recommended the use of the generic non-S3 uploader, taking advantage of the `onUpload` hook to fetch credentials from the server before uploading.

This PR switches the uploader to the generic version, and simplifies the `key-name` and `sign` URLs into a single `preupload` step called during the `onUpload` hook. As a result of the switch away from the S3 uploader, I also had to make a few tweaks to the `success` and `delete` endpoints, mostly to make sure the client would provide the correct parameters (which the S3 version had added automatically).

Additionally, it moves the policy creation to the server to enforce slightly stricter security and ensure malicious uploads are more difficult.

## Test Steps
I've tested this pretty extensively on the [`/foia/create` page](http://dev.muckrock.com/foi/create/), and all the steps work just like the previous version: uploading files, writing attachments to the DB, restoring attachments on reload, and deleting files.

However, because I'm not as familiar with the rest of the platform I could use help testing other upload endpoints — especially the `communication` one, which seems to work slightly differently than the `foia` and `composer` uploads.

## Future Work

For time / simplicity sake, I haven't implemented the chunked uploads yet — although it shouldn't be too difficult, since it would just require use of the `onChunkedUpload` hook in the same way we're using `onUpload` here.

Additionally, we should start storing (private) uploaded files in a different bucket than the static data. This will require a) adding a new setting variable for the user storage bucket name, and b) updating all the `FileFields` on those models to point to a different storage bucket.
