### PR TITLE
fix email backend in settings

### DIFF
--- a/muckrock/settings/staging.py
+++ b/muckrock/settings/staging.py
@@ -20,7 +20,12 @@ BANDIT_WHITELIST = [
     e.strip() for e in os.environ.get("BANDIT_WHITELIST", "").split(",") if e.strip()
 ]
 
-EMAIL_BACKEND = "bandit.backends.smtp.HijackSMTPBackend"
+SECURE_SSL_REDIRECT = True
+
+class HijackMailgunBackend(HijackBackendMixin, MailgunBackend):
+    """This backend hijacks all emails and sends them via Mailgun"""
+
+EMAIL_BACKEND = "muckrock.settings.staging.HijackMailgunBackend"
 
 # set proxy for static outgoing IP address, so we can cross
 # white list muckrock and squarelet staging sites

--- a/muckrock/settings/staging.py
+++ b/muckrock/settings/staging.py
@@ -20,8 +20,6 @@ BANDIT_WHITELIST = [
     e.strip() for e in os.environ.get("BANDIT_WHITELIST", "").split(",") if e.strip()
 ]
 
-SECURE_SSL_REDIRECT = True
-
 class HijackMailgunBackend(HijackBackendMixin, MailgunBackend):
     """This backend hijacks all emails and sends them via Mailgun"""
 


### PR DESCRIPTION
Our emails weren't sending from celery due to an incorrect SMTP backend being set. Matching this up with the muckrock staging settings.