### PR TITLE
Update EMAIL_BACKEND syntax

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -89,6 +89,7 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
+        EMAIL_BACKEND: django_mailgun.MailgunBackend
 
     - name: muckrock_celerybeat
       image: muckrock_celerybeat
@@ -104,6 +105,7 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
+        EMAIL_BACKEND: django_mailgun.MailgunBackend
     - name: muckrock_celeryworker
       image: muckrock_celeryworker
       port: 5555 # For flower celery task monitoring
@@ -119,6 +121,7 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
+        EMAIL_BACKEND: django_mailgun.MailgunBackend
 
 params:
   # define the cluster name to run the service on

--- a/muckrock/foia/constants.py
+++ b/muckrock/foia/constants.py
@@ -7,4 +7,4 @@ Constants for the FOIA app
 COMPOSER_SUBMIT_DELAY = 5 * 60
 
 # allow a composer to be edited 30 minutes after it has been submitted
-COMPOSER_EDIT_DELAY = 30 * 60
+COMPOSER_EDIT_DELAY = 5 * 60 

--- a/muckrock/foia/models/request.py
+++ b/muckrock/foia/models/request.py
@@ -771,7 +771,7 @@ class FOIARequest(models.Model):
             comm.attach_files_to_email(msg)
 
             try:
-                logger.info("sending mail")
+                logger.info("sending mail with backend: %s", backend)
                 msg.send(fail_silently=False)
             except MailgunAPIError as exc:
                 EmailError.objects.create(

--- a/muckrock/foia/models/request.py
+++ b/muckrock/foia/models/request.py
@@ -753,7 +753,7 @@ class FOIARequest(models.Model):
 
         # if we are using celery email, we want to not use it here, and use the
         # celery email backend directly.  Otherwise just use the default email backend
-        backend = getattr(settings, "CELERY_EMAIL_BACKEND", settings.EMAIL_BACKEND)
+        backend = settings.get("EMAIL_BACKEND")
         logger.info("email backend: %s", backend)
         with get_connection(backend) as email_connection:
             msg = EmailMultiAlternatives(
@@ -771,6 +771,7 @@ class FOIARequest(models.Model):
             comm.attach_files_to_email(msg)
 
             try:
+                logger.info("sending mail")
                 msg.send(fail_silently=False)
             except MailgunAPIError as exc:
                 EmailError.objects.create(

--- a/muckrock/foia/models/request.py
+++ b/muckrock/foia/models/request.py
@@ -753,8 +753,8 @@ class FOIARequest(models.Model):
 
         # if we are using celery email, we want to not use it here, and use the
         # celery email backend directly.  Otherwise just use the default email backend
-        backend = settings.get("EMAIL_BACKEND")
-        logger.info("email backend: %s", backend)
+        backend = 'django_mailgun.MailgunBackend'
+        logger.info("email backend: %s", settings.get("EMAIL_BACKEND"))
         with get_connection(backend) as email_connection:
             msg = EmailMultiAlternatives(
                 subject=comm.subject,

--- a/muckrock/settings/local.py
+++ b/muckrock/settings/local.py
@@ -18,9 +18,9 @@ MIDDLEWARE = ("silk.middleware.SilkyMiddleware",) + MIDDLEWARE
 
 INSTALLED_APPS += ("silk",)
 
-SILKY_PYTHON_PROFILER = True
-SILKY_PYTHON_PROFILER_BINARY = True
-SILKY_META = True
+SILKY_PYTHON_PROFILER = False
+SILKY_PYTHON_PROFILER_BINARY = False
+SILKY_META = False
 
 DEBUG_TOOLBAR_PANELS = [
     "debug_toolbar.panels.versions.VersionsPanel",


### PR DESCRIPTION
The app is still incorrectly trying to use the default django smtp backend, this is yet another attempt to override it with the mailgun backend. 

these logged out two different things:
```python
backend = settings.EMAIL_BACKEND
logger.info("email backend: %s", backend)
logger.info(settings.EMAIL_BACKEND)
```
So I am setting the backend directly and trying out a `.get()` to fetch the correct setting, and also providing the ENV var so it doesn't have to use the default value, and some more logging. 

Also, the silk profiler was slowing things to a crawl locally, @pandringa flagged this so I disabled. 