### PR TITLE
store state of foia_send_email in celery, more logging

### DIFF
--- a/muckrock/foia/models/request.py
+++ b/muckrock/foia/models/request.py
@@ -737,6 +737,7 @@ class FOIARequest(models.Model):
         from_email, _ = EmailAddress.objects.get_or_create(
             email=self.get_request_email()
         )
+        logger.info("starting delayed email send to: %s from: %s", self.email, from_email)
 
         body = self.render_msg_body(
             comm=comm,

--- a/muckrock/foia/tasks.py
+++ b/muckrock/foia/tasks.py
@@ -971,7 +971,7 @@ def clean_export_csv():
                     key.delete()
 
 
-@task(ignore_result=True, max_retries=10, name="muckrock.foia.tasks.foia_send_email")
+@task(max_retries=10, name="muckrock.foia.tasks.foia_send_email")
 def foia_send_email(foia_pk, comm_pk, options, **kwargs):
     """Send outgoing request emails asynchrnously"""
     # We do not want to do this using djcelery-email, as that
@@ -980,6 +980,7 @@ def foia_send_email(foia_pk, comm_pk, options, **kwargs):
     try:
         foia = FOIARequest.objects.get(pk=foia_pk)
         comm = FOIACommunication.objects.get(pk=comm_pk)
+        logger.info("starting delayed email for foia: %s, comm: %s", foia, comm)
         foia.send_delayed_email(comm, **options)
     except IOError as exc:
         countdown = (2 ** foia_send_email.request.retries) * 60 + randint(0, 300)


### PR DESCRIPTION
The celery app receives the `foia_send_email` task:

```
[2021-04-10 15:26:13,220: INFO/MainProcess] Received task: muckrock.foia.tasks.foia_send_email[d3768e42-eb4f-494d-87d3-67b5622525de] 
```
and then...nothing. Adding some more logging, and storing the task state so I can more easily inspect whats going on with celery control (https://docs.celeryproject.org/en/latest/userguide/workers.html?highlight=revoke#dump-of-currently-executing-tasks)