### PR TITLE
More logging tweaks

### DIFF
--- a/muckrock/foia/models/request.py
+++ b/muckrock/foia/models/request.py
@@ -753,8 +753,9 @@ class FOIARequest(models.Model):
 
         # if we are using celery email, we want to not use it here, and use the
         # celery email backend directly.  Otherwise just use the default email backend
-        backend = getattr(settings, "CELERY_EMAIL_BACKEND", settings.EMAIL_BACKEND)
-        logger.info("email backend: %s", backend)
+        backend = 'django_mailgun.MailgunBackend'
+        logger.info("email backend from settings: %s", settings.EMAIL_BACKEND)
+        logger.info("backend hardcoded: %s", backend)
         with get_connection(backend) as email_connection:
             msg = EmailMultiAlternatives(
                 subject=comm.subject,
@@ -762,7 +763,7 @@ class FOIARequest(models.Model):
                 from_email=str(from_email),
                 to=[str(self.email)],
                 cc=[str(e) for e in self.cc_emails.all() if e.status == "good"],
-                bcc=["diagnostics@muckrock.com"],
+                #  bcc=["diagnostics@muckrock.com"],
                 headers={"X-Mailgun-Variables": {"email_id": email_comm.pk}},
                 connection=email_connection,
             )

--- a/muckrock/settings/base.py
+++ b/muckrock/settings/base.py
@@ -409,7 +409,7 @@ MAILGUN_ACCESS_KEY = os.environ.get("MAILGUN_ACCESS_KEY")
 MAILGUN_SERVER_NAME = os.environ.get("MAILGUN_SERVER_NAME")
 
 EMAIL_SUBJECT_PREFIX = "[Muckrock]"
-EMAIL_BACKEND = os.environ.get(EMAIL_BACKEND, "django_mailgun.MailgunBackend")
+EMAIL_BACKEND = os.environ.get("EMAIL_BACKEND", "django_mailgun.MailgunBackend")
 
 DOCUMENTCLOUD_USERNAME = os.environ.get("DOCUMENTCLOUD_USERNAME")
 DOCUMENTCLOUD_PASSWORD = os.environ.get("DOCUMENTCLOUD_PASSWORD")


### PR DESCRIPTION
I have now logged my way through the entire stacktrace, and noticed there was possibly a syntax error in a log message that was causing a celery task run async to fail silently (cool). Fixed that and also removed bcc'ing muckrock's diagnostics email. 