### PR TITLE
Remove hardcoded email backend, restore bandit email

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -89,7 +89,7 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
-        EMAIL_BACKEND: 'bandit.backends.smtp.HijackSMTPBackend'
+        EMAIL_BACKEND: bandit.backends.smtp.HijackSMTPBackend
 
     - name: muckrock_celerybeat
       image: muckrock_celerybeat
@@ -105,7 +105,7 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
-        EMAIL_BACKEND: 'bandit.backends.smtp.HijackSMTPBackend'
+        EMAIL_BACKEND: bandit.backends.smtp.HijackSMTPBackend
     - name: muckrock_celeryworker
       image: muckrock_celeryworker
       port: 5555 # For flower celery task monitoring
@@ -121,7 +121,7 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
-        EMAIL_BACKEND: 'bandit.backends.smtp.HijackSMTPBackend'
+        EMAIL_BACKEND: bandit.backends.smtp.HijackSMTPBackend
 
 params:
   # define the cluster name to run the service on

--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -89,7 +89,7 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
-        EMAIL_BACKEND: django_mailgun.MailgunBackend
+        EMAIL_BACKEND: 'bandit.backends.smtp.HijackSMTPBackend'
 
     - name: muckrock_celerybeat
       image: muckrock_celerybeat
@@ -105,7 +105,7 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
-        EMAIL_BACKEND: django_mailgun.MailgunBackend
+        EMAIL_BACKEND: 'bandit.backends.smtp.HijackSMTPBackend'
     - name: muckrock_celeryworker
       image: muckrock_celeryworker
       port: 5555 # For flower celery task monitoring
@@ -121,7 +121,7 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
-        EMAIL_BACKEND: django_mailgun.MailgunBackend
+        EMAIL_BACKEND: 'bandit.backends.smtp.HijackSMTPBackend'
 
 params:
   # define the cluster name to run the service on

--- a/muckrock/foia/models/request.py
+++ b/muckrock/foia/models/request.py
@@ -754,7 +754,7 @@ class FOIARequest(models.Model):
 
         # if we are using celery email, we want to not use it here, and use the
         # celery email backend directly.  Otherwise just use the default email backend
-        backend = 'django_mailgun.MailgunBackend'
+        backend = settings.EMAIL_BACKEND
         logger.info("email backend from settings: %s", settings.EMAIL_BACKEND)
         logger.info("backend hardcoded: %s", backend)
         with get_connection(backend) as email_connection:


### PR DESCRIPTION
Email finally works with a hardcoded mailgun backend, now I want it to properly read from the settings file and to use the bandit backend so we don't accidentally spam agencies. 