### PR TITLE
feat: Enable separate S3 bucket for user uploads

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -49,7 +49,10 @@ context:
         - actions:
             - s3:*
           resources:
+            - arn:aws:s3:::wp-muckrock-dev
             - arn:aws:s3:::wp-muckrock-dev/*
+            - arn:aws:s3:::wp-muckrock-uploads-dev
+            - arn:aws:s3:::wp-muckrock-uploads-dev/*
         - actions:
             - cloudfront:ListDistributions
             - cloudfront:CreateInvalidation
@@ -84,12 +87,14 @@ context:
         HealthCheck:
           Command: ["CMD-SHELL", "curl -f http://127.0.0.1:5000/watchman || exit 1"]
           Timeout: 20
-      environment:
+      environment: &base_env # below is also applied to celery containers
         ALLOWED_HOSTS: "*"
         BANDIT_EMAIL: news-engineering-qa@washpost.com
         AWS_STORAGE_BUCKET_NAME: wp-muckrock-dev
+        AWS_MEDIA_BUCKET_NAME: wp-muckrock-uploads-dev
+        AWS_MEDIA_QUERYSTRING_AUTH: true
+        AWS_STORAGE_DEFAULT_ACL: "private"
         CLOUDFRONT_DOMAIN: wp-muckrock-dev.news-engineering.aws.wapo.pub
-        AWS_STORAGE_DEFAULT_ACL: ""
         DJANGO_SETTINGS_MODULE: muckrock.settings.staging
         MAILGUN_SERVER_NAME: foia-requests-dev.news-engineering.aws.wapo.pub
         POSTGRES_DB: muckrock
@@ -104,14 +109,7 @@ context:
         HealthCheck:
           Command: ["CMD-SHELL", "celery inspect ping -A muckrock.core.celery || exit 1"]
       environment:
-        ALLOWED_HOSTS: "*"
-        BANDIT_EMAIL: news-engineering-qa@washpost.com
-        DJANGO_SETTINGS_MODULE: muckrock.settings.staging
-        MAILGUN_SERVER_NAME: foia-requests-dev.news-engineering.aws.wapo.pub
-        POSTGRES_DB: muckrock
-        POSTGRES_PORT: 5432
-        SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
-        EMAIL_BACKEND: bandit.backends.smtp.HijackSMTPBackend
+        <<: *base_env # apply env from django
     - name: muckrock_celeryworker
       image: muckrock_celeryworker
       port: 5555 # For flower celery task monitoring
@@ -120,14 +118,7 @@ context:
         HealthCheck:
           Command: ["CMD-SHELL", "celery inspect ping -A muckrock.core.celery || exit 1"]
       environment:
-        ALLOWED_HOSTS: "*"
-        BANDIT_EMAIL: news-engineering-qa@washpost.com
-        DJANGO_SETTINGS_MODULE: muckrock.settings.staging
-        MAILGUN_SERVER_NAME: foia-requests-dev.news-engineering.aws.wapo.pub
-        POSTGRES_DB: muckrock
-        POSTGRES_PORT: 5432
-        SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
-        EMAIL_BACKEND: bandit.backends.smtp.HijackSMTPBackend
+        <<: *base_env # apply env from django
 
 params:
   # define the cluster name to run the service on

--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -100,7 +100,6 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
-        EMAIL_BACKEND: bandit.backends.smtp.HijackSMTPBackend
 
     - name: muckrock_celerybeat
       image: muckrock_celerybeat

--- a/muckrock/agency/importers.py
+++ b/muckrock/agency/importers.py
@@ -50,7 +50,7 @@ LAST_UPDATE = 21
 
 def import_schools(file_name):
     """Import schools from spreadsheet"""
-    s3_path = f"s3://{settings.AWS_STORAGE_BUCKET_NAME}/{file_name}"
+    s3_path = f"s3://{settings.AWS_MEDIA_BUCKET_NAME}/{file_name}"
     school_district = AgencyType.objects.get(name="School District")
     with smart_open(s3_path) as tmp_file:
         reader = csv.reader(tmp_file)

--- a/muckrock/communication/importers.py
+++ b/muckrock/communication/importers.py
@@ -41,7 +41,7 @@ p_zip = re.compile(r"^\d{5}(?:-\d{4})?$")
 def import_addresses(file_name):
     """Import addresses from spreadsheet"""
     # pylint: disable=too-many-locals
-    s3_path = f"s3://{settings.AWS_STORAGE_BUCKET_NAME}/{file_name}"
+    s3_path = f"s3://{settings.AWS_MEDIA_BUCKET_NAME}/{file_name}"
     with smart_open(s3_path) as tmp_file:
         reader = csv.reader(tmp_file)
         # discard header row

--- a/muckrock/core/storage.py
+++ b/muckrock/core/storage.py
@@ -4,6 +4,7 @@ Cache classes that extend S3, for asset compression
 
 # Django
 from django.core.files.storage import get_storage_class
+from django.conf import settings
 
 # Third Party
 from storages.backends.s3boto3 import S3Boto3Storage
@@ -13,8 +14,10 @@ from storages.backends.s3boto3 import S3Boto3Storage
 
 class CachedS3Boto3Storage(S3Boto3Storage):
     """
-    S3 storage backend that saves the files locally, too.
+    S3 storage backend for static files that saves the files locally, too.
     """
+
+    bucket_name = settings.AWS_STORAGE_BUCKET_NAME
 
     def __init__(self, *args, **kwargs):
         super(CachedS3Boto3Storage, self).__init__(*args, **kwargs)
@@ -30,7 +33,14 @@ class CachedS3Boto3Storage(S3Boto3Storage):
 
 
 class MediaRootS3BotoStorage(S3Boto3Storage):
+    """
+    S3 storage backend for user-uploaded media files. 
+    (It may or may not use the same bucket as static files.)
+    """
     file_overwrite = False
+    bucket_name = settings.AWS_MEDIA_BUCKET_NAME
+    querystring_auth = settings.AWS_MEDIA_QUERYSTRING_AUTH
+    custom_domain = settings.AWS_MEDIA_CUSTOM_DOMAIN
 
 
 class QueuedS3DietStorage:

--- a/muckrock/core/tasks.py
+++ b/muckrock/core/tasks.py
@@ -34,7 +34,7 @@ class AsyncFileDownloadTask:
 
     def __init__(self, user_pk, hash_key):
         self.user = User.objects.get(pk=user_pk)
-        self.bucket = settings.AWS_STORAGE_BUCKET_NAME
+        self.bucket = settings.AWS_MEDIA_BUCKET_NAME
         today = date.today()
         self.file_key = "{dir_name}/{y:4d}/{m:02d}/{d:02d}/{md5}/{file_name}".format(
             dir_name=self.dir_name,
@@ -74,7 +74,7 @@ class AsyncFileDownloadTask:
         
         s3 = boto3.resource('s3')
         obj = s3.ObjectAcl(self.bucket, self.file_key)
-        obj.put(ACL='public-read')
+        obj.put(ACL=settings.AWS_DEFAULT_ACL)
         self.send_notification()
 
     def generate_file(self, out_file):

--- a/muckrock/core/utils.py
+++ b/muckrock/core/utils.py
@@ -253,7 +253,7 @@ def zoho_get(path, params=None):
 def get_s3_storage_bucket():
     """Return the S3 storage bucket"""
     s3 = boto3.resource("s3")
-    return s3.Bucket(settings.AWS_STORAGE_BUCKET_NAME)
+    return s3.Bucket(settings.AWS_MEDIA_BUCKET_NAME)
 
 
 def clear_cloudfront_cache(file_names):

--- a/muckrock/fine_uploader/views.py
+++ b/muckrock/fine_uploader/views.py
@@ -28,7 +28,6 @@ from muckrock.foia.models import (
     OutboundComposerAttachment,
     OutboundRequestAttachment,
 )
-from muckrock.core.storage import MediaRootS3BotoStorage
 
 
 def _success(request, model, attachment_model, fk_name):
@@ -97,11 +96,10 @@ def _session(request, model):
         return HttpResponseBadRequest()
     if not foia.has_perm(request.user, "upload_attachment"):
         return HttpResponseForbidden()
-    
+
     attms = foia.pending_attachments.filter(user=request.user, sent=False)
 
     data = []
-    storage = MediaRootS3BotoStorage()
     for attm in attms:
         data.append(
             {

--- a/muckrock/foia/models/composer.py
+++ b/muckrock/foia/models/composer.py
@@ -223,6 +223,7 @@ class FOIAComposer(models.Model):
 
     def attachments_over_size_limit(self, user):
         """Are the pending attachments for this composer over the size limit?"""
+        print(self.pending_attachments)
         total_size = sum(
             a.ffile.size for a in self.pending_attachments.filter(user=user, sent=False)
         )

--- a/muckrock/foia/models/composer.py
+++ b/muckrock/foia/models/composer.py
@@ -223,7 +223,6 @@ class FOIAComposer(models.Model):
 
     def attachments_over_size_limit(self, user):
         """Are the pending attachments for this composer over the size limit?"""
-        print(self.pending_attachments)
         total_size = sum(
             a.ffile.size for a in self.pending_attachments.filter(user=user, sent=False)
         )

--- a/muckrock/foia/models/request.py
+++ b/muckrock/foia/models/request.py
@@ -754,10 +754,7 @@ class FOIARequest(models.Model):
 
         # if we are using celery email, we want to not use it here, and use the
         # celery email backend directly.  Otherwise just use the default email backend
-        backend = settings.EMAIL_BACKEND
-        logger.info("email backend from settings: %s", settings.EMAIL_BACKEND)
-        logger.info("backend hardcoded: %s", backend)
-        with get_connection(backend) as email_connection:
+        with get_connection(settings.EMAIL_BACKEND) as email_connection:
             msg = EmailMultiAlternatives(
                 subject=comm.subject,
                 body=body,
@@ -773,7 +770,7 @@ class FOIARequest(models.Model):
             comm.attach_files_to_email(msg)
 
             try:
-                logger.info("sending mail with backend: %s", backend)
+                logger.info("sending mail with backend: %s", settings.EMAIL_BACKEND)
                 msg.send(fail_silently=False)
             except MailgunAPIError as exc:
                 EmailError.objects.create(

--- a/muckrock/foia/tasks.py
+++ b/muckrock/foia/tasks.py
@@ -740,7 +740,7 @@ def autoimport():
         log.append("Start Time: %s" % timezone.now())
         s3 = boto3.resource("s3")
         bucket = s3.Bucket(settings.AWS_AUTOIMPORT_BUCKET_NAME)
-        storage_bucket = s3.Bucket(settings.AWS_STORAGE_BUCKET_NAME)
+        storage_bucket = s3.Bucket(settings.AWS_MEDIA_BUCKET_NAME)
         for obj in bucket.objects.filter(prefix='scans/'):
             if obj.key == "scans/":
                 continue
@@ -959,7 +959,7 @@ def clean_export_csv():
         r"(\d{4})/(\d{2})/(\d{2})/[0-9a-f]+/(?:requests?|results)\.(?:csv|zip)"
     )
     s3 = boto3.resource("s3")
-    bucket = s3.Bucket(settings.AWS_STORAGE_BUCKET_NAME)
+    bucket = s3.Bucket(settings.AWS_MEDIA_BUCKET_NAME)
     older_than = date.today() - timedelta(5)
     for prefix in ["exported_csv/", "zip_request/"]:
         for obj in bucket.objects.filter(prefix=prefix):

--- a/muckrock/jurisdiction/importers.py
+++ b/muckrock/jurisdiction/importers.py
@@ -17,7 +17,7 @@ from muckrock.jurisdiction.models import Jurisdiction, Law
 def import_laws(file_name):
     """Import laws from a spreadsheet"""
     # pylint: disable=too-many-locals
-    key = f"s3://{settings.AWS_STORAGE_BUCKET_NAME}/{file_name}"
+    key = f"s3://{settings.AWS_MEDIA_BUCKET_NAME}/{file_name}"
     with smart_open(key) as law_file:
         law_reader = csv.reader(law_file)
         for (

--- a/muckrock/settings/base.py
+++ b/muckrock/settings/base.py
@@ -23,9 +23,6 @@ def boolcheck(setting):
 asynpool.PROC_ALIVE_TIMEOUT = 60.0
 
 DEBUG = False
-EMAIL_DEBUG = DEBUG
-THUMBNAIL_DEBUG = DEBUG
-AWS_DEBUG = False
 
 SITE_ROOT = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
 
@@ -96,35 +93,23 @@ COMPRESS_JS_FILTERS = []
 
 THUMBNAIL_CACHE_DIMENSIONS = True
 
+# Boto3S3Storage configuration
+DEFAULT_FILE_STORAGE = "muckrock.core.storage.MediaRootS3BotoStorage"
+THUMBNAIL_DEFAULT_STORAGE = DEFAULT_FILE_STORAGE
+STATICFILES_STORAGE = "muckrock.core.storage.CachedS3Boto3Storage"
+COMPRESS_STORAGE = STATICFILES_STORAGE
+CLEAN_S3_ON_FOIA_DELETE = True
+
+# Settings for static bucket storage
 AWS_STORAGE_BUCKET_NAME = os.environ.get(
     "AWS_STORAGE_BUCKET_NAME", "muckrock-devel2")
 AWS_AUTOIMPORT_BUCKET_NAME = os.environ.get(
     "AWS_AUTOIMPORT_BUCKET_NAME", "muckrock-autoimprot-devel"
 )
-
-if AWS_DEBUG:
-    DEFAULT_FILE_STORAGE = "muckrock.core.storage.MediaRootS3BotoStorage"
-    THUMBNAIL_DEFAULT_STORAGE = DEFAULT_FILE_STORAGE
-    STATICFILES_STORAGE = "muckrock.core.storage.CachedS3Boto3Storage"
-    COMPRESS_STORAGE = STATICFILES_STORAGE
-    CLEAN_S3_ON_FOIA_DELETE = True
-    AWS_S3_CUSTOM_DOMAIN = os.environ.get("CLOUDFRONT_DOMAIN")
-    BASE_URL = "https://" + AWS_S3_CUSTOM_DOMAIN if AWS_S3_CUSTOM_DOMAIN else f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
-    STATIC_URL = BASE_URL + "/static/"
-    COMPRESS_URL = STATIC_URL
-    MEDIA_URL = BASE_URL + "/media/"
-else:
-    STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
-    STATIC_URL = "/static/"
-    MEDIA_URL = "/media/"
-    CLEAN_S3_ON_FOIA_DELETE = False
-
-STATICFILES_FINDERS = (
-    "django.contrib.staticfiles.finders.FileSystemFinder",
-    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
-    "compressor.finders.CompressorFinder",
-)
-
+AWS_S3_CUSTOM_DOMAIN = os.environ.get("CLOUDFRONT_DOMAIN")
+STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/" if AWS_S3_CUSTOM_DOMAIN else f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/"
+COMPRESS_URL = STATIC_URL
+COMPRESS_ENABLED = True
 AWS_QUERYSTRING_AUTH = False
 AWS_S3_SECURE_URLS = True
 AWS_HEADERS = {
@@ -136,6 +121,25 @@ AWS_S3_MAX_MEMORY_SIZE = int(os.environ.get(
     "AWS_S3_MAX_MEMORY_SIZE", 16 * 1024 * 1024))
 AWS_S3_MIN_PART_SIZE = int(os.environ.get(
     "AWS_S3_MIN_PART_SIZE", 16 * 1024 * 1024))
+
+# Set these ENV vars for a separate user-data storage bucket (otherwise matches storage settings above)
+AWS_MEDIA_BUCKET_NAME = os.environ.get("AWS_MEDIA_BUCKET_NAME", AWS_STORAGE_BUCKET_NAME)
+AWS_MEDIA_QUERYSTRING_AUTH = os.environ.get("AWS_MEDIA_QUERYSTRING_AUTH", AWS_QUERYSTRING_AUTH)
+AWS_MEDIA_CUSTOM_DOMAIN = os.environ.get("MEDIA_CLOUDFRONT_DOMAIN")
+
+if AWS_MEDIA_BUCKET_NAME == AWS_STORAGE_BUCKET_NAME:
+    # Inherit bucket/cloudfront settings from static data if they match
+    MEDIA_URL = ""
+    AWS_MEDIA_CUSTOM_DOMAIN = AWS_S3_CUSTOM_DOMAIN
+else:
+    # Infer the media url from the custom domain or bucket name settings
+    MEDIA_URL = f"https://{AWS_MEDIA_CUSTOM_DOMAIN}/" if AWS_MEDIA_CUSTOM_DOMAIN else f"https://{AWS_MEDIA_BUCKET_NAME}.s3.amazonaws.com/"
+
+STATICFILES_FINDERS = (
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+    "compressor.finders.CompressorFinder",
+)
 
 TEMPLATES = [
     {

--- a/muckrock/settings/heroku.py
+++ b/muckrock/settings/heroku.py
@@ -12,21 +12,6 @@ from muckrock.settings.base import *
 INSTALLED_APPS = ("scout_apm.django",) + INSTALLED_APPS
 USE_SCOUT = True
 
-# media and static asset handling
-DEFAULT_FILE_STORAGE = "muckrock.core.storage.MediaRootS3BotoStorage"
-THUMBNAIL_DEFAULT_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-STATICFILES_STORAGE = "muckrock.core.storage.CachedS3Boto3Storage"
-COMPRESS_STORAGE = STATICFILES_STORAGE
-AWS_S3_CUSTOM_DOMAIN = os.environ.get("CLOUDFRONT_DOMAIN")
-if AWS_S3_CUSTOM_DOMAIN:
-    STATIC_URL = "https://" + AWS_S3_CUSTOM_DOMAIN + "/"
-else:
-    STATIC_URL = "https://" + AWS_STORAGE_BUCKET_NAME + ".s3.amazonaws.com/"
-COMPRESS_URL = STATIC_URL
-MEDIA_URL = STATIC_URL + "media/"
-CLEAN_S3_ON_FOIA_DELETE = True
-COMPRESS_ENABLED = True
-
 TEMPLATES[0]["OPTIONS"]["loaders"] = [
     (
         "django.template.loaders.cached.Loader",

--- a/muckrock/settings/local.py
+++ b/muckrock/settings/local.py
@@ -9,9 +9,10 @@ Settings used when developing locally
 from muckrock.settings.base import *
 
 DEBUG = True
-EMAIL_DEBUG = DEBUG
-THUMBNAIL_DEBUG = DEBUG
-AWS_DEBUG = False
+
+# Loads static files locally
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+STATIC_URL = "/static/"
 
 MIDDLEWARE += ("muckrock.settings.local.ExceptionLoggingMiddleware",)
 MIDDLEWARE = ("silk.middleware.SilkyMiddleware",) + MIDDLEWARE

--- a/muckrock/settings/local.py
+++ b/muckrock/settings/local.py
@@ -67,6 +67,7 @@ DEBUG_TOOLBAR_CONFIG = {
 
 EMAIL_HOST = "dev.mailhog.com"
 EMAIL_PORT = 1025
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 QUERYCOUNT = {"DISPLAY_DUPLICATES": 10}
 

--- a/muckrock/task/tasks.py
+++ b/muckrock/task/tasks.py
@@ -97,8 +97,8 @@ def snail_mail_bulk_pdf_task(pdf_name, get, **kwargs):
 
     s3 = boto3.client("s3")
     s3.upload_file(
-        bulk_pdf, settings.AWS_STORAGE_BUCKET_NAME, pdf_name,
-        ExtraArgs={'ACL': 'public-read'}
+        bulk_pdf, settings.AWS_MEDIA_BUCKET_NAME, pdf_name,
+        ExtraArgs={'ACL': settings.AWS_DEFAULT_ACL}
     )
 
 


### PR DESCRIPTION
## Description
Since it's a best security practice, we want to store user data in a separate (private) bucket and use query string auth to access its contents — rather than co-locate user uploads with static assets like JS/CSS/Images. Thankfully, Django has a relatively easy way to manage these two concepts separately — via the `MEDIA_URL` and `STATIC_URL` options — and we can harness the two separate `S3Boto3Storage` classes for each type to send the contents to different buckets.

This PR adds a number of new environment variables to configure options for this new bucket, including the bucket name, (optional) cloudfront distribution, and whether to use query string authentication for it. It also cleans up the handling of the existing variables, deprecating the tricky `AWS_DEBUG` variable (which had to be set in multiple places) in place of a simple override in the `local.py` file. As a result, local development will now use static files from your own filesystem combined with S3-based file uploads.

Finally, I cleaned up the `config.yml` file to use a single environment definition re-used across all containers, to limit the likelihood of weird bugs happening and make future changes simpler.

## Testing
I've tested many iterations of settings including:
- [x] Single bucket for static assets and media (i.e. backwards compatibility)
- [x] Two buckets for static assets and media (i.e. our plan)
- [x] Querystring auth on/off
- [x] Different cloudfront distribution options

For testing, add the following to your `.django` settings (to emulate our planned deployment setup):
```
AWS_STORAGE_BUCKET_NAME=wp-muckrock-dev
AWS_MEDIA_BUCKET_NAME=wp-muckrock-uploads-dev
CLOUDFRONT_DOMAIN=wp-muckrock-dev.news-engineering.aws.wapo.pub
AWS_STORAGE_DEFAULT_ACL="private"
AWS_MEDIA_QUERYSTRING_AUTH=true
```

Then, try to upload attachments with some FOIA requests and view those files in the submitted request view. (Also try deleting attached files, or reloading the page to be sure attachments are persisted.)