### PR TITLE
NE-332: Use mailhog for local emails

### DIFF
--- a/muckrock/settings/local.py
+++ b/muckrock/settings/local.py
@@ -67,7 +67,7 @@ DEBUG_TOOLBAR_CONFIG = {
 
 EMAIL_HOST = "dev.mailhog.com"
 EMAIL_PORT = 1025
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 
 QUERYCOUNT = {"DISPLAY_DUPLICATES": 10}
 


### PR DESCRIPTION
## Description

@simongle and I wrote up an entire ticket for doing this, then realized that Squarelet already has a running mailhog instance! Since Muckrock and Squarelet run in the same docker network, all we have to do is set up the config to use SMTP and point at that instance.

## Ticket
https://arcpublishing.atlassian.net/browse/NE-332

## Test steps

- Run squarelet: `cd squarelet && docker-compose -f local.yml up`
- Run muckrock: `cd muckrock && docker-compose -f local.yml up`
- File a FOIA request, and navigate to http://dev.squarelet.com
- Ensure the email appears after 5 minutes

## Screenshots
<img width="1552" alt="Screen Shot 2021-04-12 at 7 06 13 PM" src="https://user-images.githubusercontent.com/3749412/114473659-a9d1ed00-9bc2-11eb-9a07-3e9ef310158b.png">
