### PR TITLE
Better Celery Debugging for Lob

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -19,8 +19,7 @@ services:
       - ~/.aws:/root/.aws
     environment:
       - IPYTHONDIR=/app/.ipython
-      # - MIGRATE=true
-      - AWS_PROFILE=${AWS_PROFILE}
+      - AWS_PROFILE
     env_file:
       - ./.envs/.local/.django
       - ./.envs/.local/.postgres
@@ -51,6 +50,8 @@ services:
       - 5434:5432
 
   muckrock_redis:
+    ports:
+      - 6379:6379
     image: redis:3.2
 
   muckrock_celeryworker:
@@ -62,6 +63,7 @@ services:
     command: ["celery", "-A", "muckrock.core.celery", "worker", "-l", "INFO"]
     environment:
       - C_FORCE_ROOT=true
+      - AWS_PROFILE
     networks:
       default:
         aliases: []
@@ -78,6 +80,8 @@ services:
       - muckrock_redis
       - muckrock_postgres
     command: ["celery", "-A", "muckrock.core.celery", "beat", "-l", "INFO"]
+    environment:
+      - AWS_PROFILE 
     networks:
       default:
         aliases: []

--- a/muckrock/core/celery.py
+++ b/muckrock/core/celery.py
@@ -1,10 +1,10 @@
 """Celery configuration app"""
 # Django
-from celery import Celery
+from celery import Celery, signals
 from django.conf import settings
 
 # Standard Library
-import os
+import os, logging
 
 # Third Party
 import scout_apm.celery
@@ -12,6 +12,7 @@ import scout_apm.celery
 # set the default Django settings module for the 'celery' program.
 #  os.environ.setdefault("DJANGO_SETTINGS_MODULE", "muckrock.settings.local")
 
+logger = logging.getLogger(__name__)
 app = Celery("muckrock")
 
 # Using a string here means the worker doesn't have to serialize
@@ -25,3 +26,18 @@ app.autodiscover_tasks()
 
 if settings.USE_SCOUT:
     scout_apm.celery.install(app)
+
+@signals.task_retry.connect
+@signals.task_failure.connect
+@signals.task_revoked.connect
+def on_task_failure(**kwargs):
+    """Abort transaction on task errors.
+    """
+    # celery exceptions will not be published to `sys.excepthook`. therefore we have to create another handler here.
+    from traceback import format_tb
+
+    logger.error('[task:%s:%s]' % (kwargs.get('task_id'), kwargs['sender'].request.correlation_id, )
+              + '\n'
+              + ''.join(format_tb(kwargs.get('traceback', [])))
+              + '\n'
+              + str(kwargs.get('exception', '')))

--- a/muckrock/foia/tasks.py
+++ b/muckrock/foia/tasks.py
@@ -1008,6 +1008,7 @@ def prepare_snail_mail(comm_pk, category, switch, extra, force=False, **kwargs):
     """Determine if we should use Lob or a snail mail task to send this snail mail"""
     # pylint: disable=too-many-locals
     comm = FOIACommunication.objects.get(pk=comm_pk)
+    logger.info("comm: %s", comm)
     # amount may be a string if it was JSON serialized from a Decimal
     amount = float(extra.get("amount", 0))
 
@@ -1022,7 +1023,6 @@ def prepare_snail_mail(comm_pk, category, switch, extra, force=False, **kwargs):
             error_msg=error_msg,
             **extra,
         )
-
     if category == "p":
         address = comm.foia.agency.get_addresses("check").first()
         if address is None:
@@ -1030,7 +1030,7 @@ def prepare_snail_mail(comm_pk, category, switch, extra, force=False, **kwargs):
             return
     else:
         address = comm.foia.address
-
+    logger.info("sending mail to %s", address)
     for test, reason in [
         (not config.AUTO_LOB and not force, "auto"),
         (not address, "addr"),


### PR DESCRIPTION
Lob snail mail requests were silently failing, Peter found a need snippit using celery signals to log out stack traces for failed celery tasks, which helped us debug the issue locally. 

I'd like to add this enhanced logging to the dev stage so I can more info from cloudwatch on what is preventing lob from sending out mail. 

@pandringa I decided to not put the logging behind a config flag because when would we not want stack traces in cloudwatch? They will never render to the user. 