### PR TITLE
Use python 3.8 image with correct font files

### DIFF
--- a/compose/dev/django/Dockerfile.celerybeat
+++ b/compose/dev/django/Dockerfile.celerybeat
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM 912288704264.dkr.ecr.us-east-1.amazonaws.com/python_38
+FROM 912288704264.dkr.ecr.us-east-1.amazonaws.com/shared/python:3.8
 
 ENV PYTHONUNBUFFERED 1
 ARG DEPLOYMENT_ENV=dev

--- a/compose/dev/django/Dockerfile.celerybeat
+++ b/compose/dev/django/Dockerfile.celerybeat
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM 566093341066.dkr.ecr.us-east-1.amazonaws.com/python_38
+FROM 912288704264.dkr.ecr.us-east-1.amazonaws.com/python_38
 
 ENV PYTHONUNBUFFERED 1
 ARG DEPLOYMENT_ENV=dev

--- a/compose/dev/django/Dockerfile.celerybeat
+++ b/compose/dev/django/Dockerfile.celerybeat
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM public.ecr.aws/bitnami/python:3.8
+FROM 566093341066.dkr.ecr.us-east-1.amazonaws.com/python_38
 
 ENV PYTHONUNBUFFERED 1
 ARG DEPLOYMENT_ENV=dev

--- a/compose/dev/django/Dockerfile.celeryworker
+++ b/compose/dev/django/Dockerfile.celeryworker
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM 912288704264.dkr.ecr.us-east-1.amazonaws.com/python_38
+FROM 912288704264.dkr.ecr.us-east-1.amazonaws.com/shared/python:3.8
 
 ENV PYTHONUNBUFFERED 1
 ARG DEPLOYMENT_ENV=dev

--- a/compose/dev/django/Dockerfile.celeryworker
+++ b/compose/dev/django/Dockerfile.celeryworker
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM 566093341066.dkr.ecr.us-east-1.amazonaws.com/python_38
+FROM 912288704264.dkr.ecr.us-east-1.amazonaws.com/python_38
 
 ENV PYTHONUNBUFFERED 1
 ARG DEPLOYMENT_ENV=dev

--- a/compose/dev/django/Dockerfile.celeryworker
+++ b/compose/dev/django/Dockerfile.celeryworker
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM public.ecr.aws/bitnami/python:3.8
+FROM 566093341066.dkr.ecr.us-east-1.amazonaws.com/python_38
 
 ENV PYTHONUNBUFFERED 1
 ARG DEPLOYMENT_ENV=dev

--- a/compose/dev/django/Dockerfile.django
+++ b/compose/dev/django/Dockerfile.django
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM 912288704264.dkr.ecr.us-east-1.amazonaws.com/python_38
+FROM 912288704264.dkr.ecr.us-east-1.amazonaws.com/shared/python:3.8
 
 ENV PYTHONUNBUFFERED 1
 ARG DEPLOYMENT_ENV=dev

--- a/compose/dev/django/Dockerfile.django
+++ b/compose/dev/django/Dockerfile.django
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM 566093341066.dkr.ecr.us-east-1.amazonaws.com/python_38
+FROM 912288704264.dkr.ecr.us-east-1.amazonaws.com/python_38
 
 ENV PYTHONUNBUFFERED 1
 ARG DEPLOYMENT_ENV=dev

--- a/compose/dev/django/Dockerfile.django
+++ b/compose/dev/django/Dockerfile.django
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM public.ecr.aws/bitnami/python:3.8
+FROM 566093341066.dkr.ecr.us-east-1.amazonaws.com/python_38
 
 ENV PYTHONUNBUFFERED 1
 ARG DEPLOYMENT_ENV=dev


### PR DESCRIPTION
We were using a different docker image locally (python 3.8) vs on dev. On dev we saw this error when trying to generate a PDF:

`TTF Font file not found: /usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf`

I checked and locally that font file exists in the python 3.8 image.

Peter graciously pushed up a clone of the base python 3.8 image to our ECR, so this switches the dockerfiles to use that. 