### PR TITLE
feat: Add bandit whitelist to staging env

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -90,6 +90,7 @@ context:
       environment: &base_env # below is also applied to celery containers
         ALLOWED_HOSTS: "*"
         BANDIT_EMAIL: news-engineering-qa@washpost.com
+        BANDIT_WHITELIST: washpost.com
         AWS_STORAGE_BUCKET_NAME: wp-muckrock-dev
         AWS_MEDIA_BUCKET_NAME: wp-muckrock-uploads-dev
         AWS_MEDIA_QUERYSTRING_AUTH: true


### PR DESCRIPTION
Currently, the staging environment hijacks all outgoing email using django-email-bandit, to redirect every message to the `news-eng-qa` address. That's handy when it comes to testing out emails to agencies, but it gets a little bit annoying when it comes to internal emails: for example, the listserv gets three copies of the "Daily Digest" email every morning, or CSV download emails go to the entire group rather than people who requested them.

According to the [django-email-bandit documentation](https://github.com/caktus/django-email-bandit#installation), there's a `BANDIT_WHITELIST` settings variable which can be used to whitelist specific addresses or domains so that outgoing email can still reach them. By adding `washpost.com` to the whitelist, we're ensuring that emails directed at specific users will go to them directly, but still redirecting agency requests, etc to the `news-eng-qa` address.

The `staging.py` [file](https://github.com/WPMedia/muckrock/blob/develop/muckrock/settings/staging.py#L19-L21) already has logic to parse a comma-separated environment variable and split them into an array stored in `settings.BANDIT_WHITELIST`, which makes this PR easy: we just have to set the variable in the cloudformation config. 