### PR TITLE
Fix: Bulk mail download button

### DIFF
--- a/muckrock/assets/js/task.js
+++ b/muckrock/assets/js/task.js
@@ -100,17 +100,16 @@ function formHasAction(taskForm, action) {
     return actionExists;
 }
 
-function checkPdfExists(pdfName) {
-  var url = 'https://muckrock.s3.amazonaws.com/' + pdfName;
+function checkPdfExists(head_url, get_url) {
   $.ajax({
-    url: url,
+    url: head_url,
     type: 'head',
     success: function() {
       $('#snail-mail-bulk-download').text('Downloading');
-      window.location.href = url;
+      window.location.href = get_url;
     },
     error: function() {
-      setTimeout(checkPdfExists, 5000, pdfName);
+      setTimeout(checkPdfExists, 5000, head_url, get_url);
     }
   });
 }
@@ -207,7 +206,7 @@ $('document').ready(function(){
       data: window.location.search.substr(1),
       type: 'get',
       success: function(data) {
-        checkPdfExists(data['pdf_name']);
+        checkPdfExists(data['head_url'], data['get_url']);
       },
       error: function() {
         $(this.text('Error!'));

--- a/muckrock/settings/local.py
+++ b/muckrock/settings/local.py
@@ -71,6 +71,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 
 QUERYCOUNT = {"DISPLAY_DUPLICATES": 10}
 
+COMPRESS_ENABLED = False
 CACHE_DEBUG = False
 if CACHE_DEBUG:
     CACHES["default"] = {

--- a/muckrock/task/tasks.py
+++ b/muckrock/task/tasks.py
@@ -96,7 +96,7 @@ def snail_mail_bulk_pdf_task(pdf_name, get, **kwargs):
     bulk_pdf.seek(0)
 
     s3 = boto3.client("s3")
-    s3.upload_file(
+    s3.upload_fileobj(
         bulk_pdf, settings.AWS_MEDIA_BUCKET_NAME, pdf_name,
         ExtraArgs={'ACL': settings.AWS_DEFAULT_ACL}
     )

--- a/muckrock/task/views.py
+++ b/muckrock/task/views.py
@@ -27,6 +27,7 @@ import logging
 from datetime import datetime
 
 # Third Party
+import boto3
 from django_filters import FilterSet
 
 # MuckRock
@@ -733,7 +734,21 @@ def snail_mail_bulk_pdf(request):
     # pylint: disable=unused-argument
     pdf_name = timezone.now().strftime("snail_mail_pdfs/%Y/%m/%d/%H-%M-%S.pdf")
     snail_mail_bulk_pdf_task.delay(pdf_name, request.GET.dict())
-    return JsonResponse({"pdf_name": pdf_name})
+
+    # Generate GET/HEAD presigned URLs for the client
+    urls = {}
+    s3 = boto3.client('s3')
+    for action in ['head', 'get']:
+        urls[f'{action}_url'] = s3.generate_presigned_url(
+            ClientMethod=f'{action}_object', 
+            Params={
+                'Bucket': settings.AWS_MEDIA_BUCKET_NAME, 
+                'Key': pdf_name
+            },
+            ExpiresIn=3600
+        )
+
+    return JsonResponse(urls)
 
 
 @user_passes_test(lambda u: u.is_staff)


### PR DESCRIPTION
## Description

Some issues with the `boto2 -> boto3` migration (and private S3 buckets) broke the "Generate Bulk PDF" functionality on the [Snail Mail tasks page](http://dev.muckrock.com/task/snail-mail/).

The button works by requesting a route (in `task/views.py`) which generates two S3 URLs and kicks off an async task to generate a bulk PDF. While the task is running in the background, the client polls S3 with `HEAD` requests until it sees the object there, and then download the PDF for the user with a `GET` request.

This PR fixes it, with a couple of changes:
- Removing hard-coded references to the `muckrock` bucket, in favor of `settings.AWS_MEDIA_BUCKET_NAME`
- Passing presigned URLs to the client
- Creating different presaged URLs for the `GET` and `HEAD` operations (since the signatures have to be different)
- Disables JS caching on the local server, which made testing harder

## Test steps

```
inv npm "run build" && inv manage collectstatic 
```

Go to the snail mail tasks page: http://dev.muckrock.com/task/snail-mail/

If there aren't any mail tasks there, create a new snail mail FOIA request, and come back

Click "Generate Bulk PDF" in the top left corner. You should see a PDF download.