### PR TITLE
revert healthcheck path in dev

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -34,7 +34,7 @@ context:
     default_scale: 1 # TODO we will want more for prod but this makes debugging easier
 
     # Health check, defaults to "/"
-    health_check_path: /watchman
+    health_check_path: /
 
     # health check info and defaults
     health_check_interval_seconds: 30


### PR DESCRIPTION
The task in ECS wasn't placing, and the only thing in dev that changed with #60 was the `service.health_check_path`. If this path doesn't return a 200 immediately, all of the containers will be stuck in pending. I want to try reverting this to see if it fixes the task placement issue, if so I'll tweak the healthcheck a bit more. 