### PR TITLE
Hotfix: enable dynamic service name

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -32,7 +32,10 @@ context:
   service:
     # Initial number of tasks to run, defaults to 2
     default_scale: 1 # TODO we will want more for prod but this makes debugging easier
-
+    
+    # Append a random string to each service instance
+    # allowing creation of the replacement before destroying the previous generation
+    dynamic_service_name: true
     # Health check, defaults to "/"
     health_check_path: /
 

--- a/cfn/configs/prod/us-east-1/config.yml
+++ b/cfn/configs/prod/us-east-1/config.yml
@@ -2,7 +2,7 @@ template: cfn/templates/ecs-service.template.yml
 stack_name: muckrock-prod
 region: us-east-1
 context:
-  name: muckrock
+  name: muckrock-foia
   environment: prod
 
   # Not required, only required if the load balancer or target group

--- a/cfn/configs/prod/us-east-1/config.yml
+++ b/cfn/configs/prod/us-east-1/config.yml
@@ -2,7 +2,7 @@ template: cfn/templates/ecs-service.template.yml
 stack_name: muckrock-prod
 region: us-east-1
 context:
-  name: muckrock-foia
+  name: muckrock
   environment: prod
 
   # Not required, only required if the load balancer or target group
@@ -28,6 +28,10 @@ context:
   service:
     # Initial number of tasks to run, defaults to 2
     default_scale: 1
+    
+    # Append a random string to each service instance
+    # allowing creation of the replacement before destroying the previous generation
+    dynamic_service_name: true
 
     # Health check, defaults to "/"
     health_check_path: /watchman


### PR DESCRIPTION
The service wasn't being torn down properly and replaced by cloudformation because the service `muckrock-prod` already existed. This enables a feature which appends a random string to the end of the service name, making it unique so that CF can spin up and tear down separately, rather than trying to overwrite a service which may just be stuck in a bad state, which ours was. 