### PR TITLE
Hotfix: Add logging to try and fix deploy

### DIFF
--- a/cfn/configs/prod/us-east-1/config.yml
+++ b/cfn/configs/prod/us-east-1/config.yml
@@ -34,7 +34,7 @@ context:
     dynamic_service_name: true
 
     # Health check, defaults to "/"
-    health_check_path: /watchman
+    health_check_path: /
 
     # health check info and defaults
     health_check_interval_seconds: 30

--- a/compose/prod/django/entrypoint
+++ b/compose/prod/django/entrypoint
@@ -41,6 +41,13 @@ echo >&2 'PostgreSQL is available'
 
 exec "$@"
 
+echo "Begging collect static files" >&2
 python /app/manage.py collectstatic --noinput
+echo "finished collect static files" >&2
+
+echo "starting file compression" >&2
 python /app/manage.py compress
-gunicorn -c file:config/gunicorn.conf.py muckrock.wsgi:application
+echo "finishing file compression" >&2
+
+echo "Starting gunicorn" >&2
+gunicorn -c file:config/gunicorn.conf.py muckrock.wsgi:application --access-logfile -

--- a/config/gunicorn.conf.py
+++ b/config/gunicorn.conf.py
@@ -10,5 +10,4 @@ workers = int(os.environ.get('GUNICORN_WORKERS', 3))
 max_requests = 50
 timeout = 120
 log_level = 'debug'
-accesslog = "/app/gunicorn.access.log"
 errorlog = "/app/gunicorn.error.log"


### PR DESCRIPTION
* Change healthcheck route to /, it was trying to hit watchman and its possible it wasn't ready and then the task would fail
* Add more logging in entrypoint for clarity
* Reroute gunicorn logging from logfile to stdout