### PR TITLE
Hotfix: temp add bandit to installed apps

### DIFF
--- a/muckrock/settings/wapo/production.py
+++ b/muckrock/settings/wapo/production.py
@@ -10,6 +10,7 @@ import requests
 from muckrock.settings.production import *
 
 # TODO Remove me once we've verified email sending in production
+INSTALLED_APPS += ("bandit",)
 EMAIL_BACKEND = "muckrock.settings.staging.HijackMailgunBackend"
 BANDIT_EMAIL = os.environ.get("BANDIT_EMAIL", "staging@muckrock.com")
 BANDIT_WHITELIST = [


### PR DESCRIPTION
We want to verify email settings in production before sending to real agencies, so we need bandit to reroute email to our qa address. It was trying to do that, but unable to find bandit templates, which led us to realize that it wasn't in installed apps (which it normally shouldn't be for production) so I added it as part of the TODO block. Relevant [stacktrace](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/muckrock-prod/log-events/prod$252Fmuckrock_celeryworker$252F696cf6618b93489bafa1de0cbf5ec0c2)
