### PR TITLE
Tweak settings for upstream integration

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -94,13 +94,7 @@ context:
         ALLOWED_HOSTS: "127.0.0.1,muckrock-dev.news-engineering.aws.wapo.pub"
         BANDIT_EMAIL: news-engineering-qa@washpost.com
         BANDIT_WHITELIST: "washpost.com,pm.me" # TODO remove me testing with personal email
-        AWS_STORAGE_BUCKET_NAME: wp-muckrock-dev
-        AWS_MEDIA_BUCKET_NAME: wp-muckrock-uploads-dev
-        AWS_MEDIA_QUERYSTRING_AUTH: true
-        AWS_STORAGE_DEFAULT_ACL: "private"
-        CLOUDFRONT_DOMAIN: wp-muckrock-dev.news-engineering.aws.wapo.pub
         DJANGO_SETTINGS_MODULE: muckrock.settings.wapo.staging
-        MAILGUN_SERVER_NAME: foia-requests-dev.news-engineering.aws.wapo.pub
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments

--- a/cfn/configs/prod/us-east-1/config.yml
+++ b/cfn/configs/prod/us-east-1/config.yml
@@ -91,13 +91,7 @@ context:
         ALLOWED_HOSTS: "127.0.0.1,muckrock-prod.news-engineering.aws.wapo.pub"
         BANDIT_EMAIL: news-engineering-qa@washpost.com
         BANDIT_WHITELIST: washpost.com
-        AWS_STORAGE_BUCKET_NAME: wp-muckrock-prod
-        AWS_MEDIA_BUCKET_NAME: wp-muckrock-uploads-prod
-        AWS_MEDIA_QUERYSTRING_AUTH: true
-        AWS_STORAGE_DEFAULT_ACL: "private"
-        CLOUDFRONT_DOMAIN: wp-muckrock-prod.news-engineering.aws.wapo.pub
         DJANGO_SETTINGS_MODULE: muckrock.settings.wapo.production
-        MAILGUN_SERVER_NAME: foi-requests.washpost.com
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments

--- a/muckrock/settings/wapo/base.py
+++ b/muckrock/settings/wapo/base.py
@@ -1,0 +1,22 @@
+from os import environ
+
+CONSTANCE_REDIS_CONNECTION = {
+    'host': environ.get("REDIS_HOST"),
+    'port': 6379,
+}
+
+# Forwarding settings for these addresses should be set in Mailgun settings
+DEFAULT_FROM_EMAIL = "info@foi-requests.washpost.com"
+DIAGNOSTIC_EMAIL = "diagnostics@foi-requests.washpost.com"
+SCANS_EMAIL = "scans@foi-requests.washpost.com"
+ASSIGNMENTS_EMAIL = "assignments@foi-requests.washpost.com"
+
+ADDRESS_NAME = "The Washington Post"
+ADDRESS_DEPT = "DEPT FOI {pk}"
+ADDRESS_STREET = "1301 K St. NW"
+ADDRESS_CITY = "Washington"
+ADDRESS_STATE = "DC"
+ADDRESS_ZIP = "20005"
+
+PHONE_NUMBER = "(202) 334-6000"
+PHONE_NUMBER_LINK = PHONE_NUMBER.translate({ord(i): None for i in "()- "})

--- a/muckrock/settings/wapo/local.py
+++ b/muckrock/settings/wapo/local.py
@@ -1,0 +1,10 @@
+from muckrock.settings.local import *
+from muckrock.settings.wapo.base import *
+
+AWS_STORAGE_BUCKET_NAME="wp-muckrock-dev"
+AWS_MEDIA_BUCKET_NAME="wp-muckrock-uploads-dev"
+CLOUDFRONT_DOMAIN="wp-muckrock-dev.news-engineering.aws.wapo.pub"
+AWS_STORAGE_DEFAULT_ACL="private"
+AWS_MEDIA_QUERYSTRING_AUTH=True
+
+MAILGUN_DOMAIN = "foia-requests-dev.news-engineering.aws.wapo.pub"

--- a/muckrock/settings/wapo/production.py
+++ b/muckrock/settings/wapo/production.py
@@ -8,6 +8,7 @@ import requests
 # pylint: disable=unused-wildcard-import
 
 from muckrock.settings.production import *
+from muckrock.settings.wapo.base import *
 
 # TODO Remove me once we've verified email sending in production
 INSTALLED_APPS += ("bandit",)
@@ -17,12 +18,15 @@ BANDIT_WHITELIST = [
     e.strip() for e in os.environ.get("BANDIT_WHITELIST", "").split(",") if e.strip()
 ]
 
-CONSTANCE_REDIS_CONNECTION = {
-    'host': os.environ.get("REDIS_HOST"),
-    'port': 6379,
-}
-
 SECURE_SSL_REDIRECT = False
+
+AWS_STORAGE_BUCKET_NAME="wp-muckrock-prod"
+AWS_MEDIA_BUCKET_NAME="wp-muckrock-uploads-prod"
+CLOUDFRONT_DOMAIN="wp-muckrock-prod.news-engineering.aws.wapo.pub"
+AWS_STORAGE_DEFAULT_ACL="private"
+AWS_MEDIA_QUERYSTRING_AUTH=True
+
+MAILGUN_DOMAIN = "foi-rquests.washpost.com"
 
 # This gets the IP address of the EC2 instance the task is
 # running on and adds it to allowed_hosts so the health

--- a/muckrock/settings/wapo/production.py
+++ b/muckrock/settings/wapo/production.py
@@ -26,7 +26,7 @@ CLOUDFRONT_DOMAIN="wp-muckrock-prod.news-engineering.aws.wapo.pub"
 AWS_STORAGE_DEFAULT_ACL="private"
 AWS_MEDIA_QUERYSTRING_AUTH=True
 
-MAILGUN_DOMAIN = "foi-rquests.washpost.com"
+MAILGUN_DOMAIN = "foi-requests.washpost.com"
 
 # This gets the IP address of the EC2 instance the task is
 # running on and adds it to allowed_hosts so the health

--- a/muckrock/settings/wapo/staging.py
+++ b/muckrock/settings/wapo/staging.py
@@ -7,15 +7,19 @@ import requests
  # pylint: disable=wildcard-import
 
 from muckrock.settings.staging import *
+from muckrock.settings.wapo.base import *
 
 UNINSTALLED_APPS = ["scout_apm.django"]
 INSTALLED_APPS = [app for app in INSTALLED_APPS if app not in UNINSTALLED_APPS]
 USE_SCOUT = False
 
-CONSTANCE_REDIS_CONNECTION = {
-    'host': os.environ.get("REDIS_HOST"),
-    'port': 6379,
-}
+AWS_STORAGE_BUCKET_NAME="wp-muckrock-dev"
+AWS_MEDIA_BUCKET_NAME="wp-muckrock-uploads-dev"
+CLOUDFRONT_DOMAIN="wp-muckrock-dev.news-engineering.aws.wapo.pub"
+AWS_STORAGE_DEFAULT_ACL="private"
+AWS_MEDIA_QUERYSTRING_AUTH=True
+
+MAILGUN_DOMAIN = "foia-requests-dev.news-engineering.aws.wapo.pub"
 
 # This gets the IP address of the EC2 instance the task is
 # running on and adds it to allowed_hosts so the health

--- a/muckrock/templates/lib/progress_bar.html
+++ b/muckrock/templates/lib/progress_bar.html
@@ -8,6 +8,6 @@ When included, should be given three parameters as a dict:
 {% endcomment %}
 {% if percentage %}
 <object class="progress-bar" {% if id %}id="{{ id }}"{% endif %}>
-    <span class="{% if '100' in percentage or 100 == percentage %}completed{% endif %} {% if state %}{{ state }}{% endif %} meter" style="width: {% if percentage|last = '%' %}{{ percentage }}{% else %}{{ percentage }}%{% endif %};"></span>
+    <span class="{% if '100' in percentage or 100 == percentage %}completed{% endif %} {% if state %}{{ state }}{% endif %} meter" style="width: {% if percentage|last == '%' %}{{ percentage }}{% else %}{{ percentage }}%{% endif %};"></span>
 </object>
 {% endif %}


### PR DESCRIPTION
After reviewing #71, I made a couple of tweaks to set appropriate values for the settings files and fix some of the things that were merged weirdly (particularly in `fine_uploader/views.py`).

I also added two new settings files: `wapo/base.py` (base wapo settings shared by all stages), and `wapo/local.py` (with local values we care about.) Now that all wapo settings can be isolated among those files, I moved a couple of values out of the `config.yml` environment variables and into the settings files instead. This will make bootstrapping the app much easier for future users.

From now on, to run the app locally, you'll need to set the following in your ENV:
```
DJANGO_SETTINGS_MODULE="muckrock.settings.wapo.local"
```