### PR TITLE
fix: re-bind environment variables to allow app to start

### DIFF
--- a/cfn/configs/dev/us-east-1/config.yml
+++ b/cfn/configs/dev/us-east-1/config.yml
@@ -98,6 +98,12 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
+        AWS_STORAGE_BUCKET_NAME: wp-muckrock-dev
+        AWS_MEDIA_BUCKET_NAME: wp-muckrock-uploads-dev
+        AWS_MEDIA_QUERYSTRING_AUTH: true
+        AWS_STORAGE_DEFAULT_ACL: "private"
+        CLOUDFRONT_DOMAIN: wp-muckrock-dev.news-engineering.aws.wapo.pub
+        MAILGUN_SERVER_NAME: foia-requests-dev.news-engineering.aws.wapo.pub
 
     - name: muckrock_celerybeat
       image: muckrock_celerybeat

--- a/cfn/configs/prod/us-east-1/config.yml
+++ b/cfn/configs/prod/us-east-1/config.yml
@@ -95,6 +95,12 @@ context:
         POSTGRES_DB: muckrock
         POSTGRES_PORT: 5432
         SQUARELET_URL: https://accounts.muckrock.com # Using prod squarelet for dev+prod environments
+        AWS_STORAGE_BUCKET_NAME: wp-muckrock-prod
+        AWS_MEDIA_BUCKET_NAME: wp-muckrock-uploads-prod
+        AWS_MEDIA_QUERYSTRING_AUTH: true
+        AWS_STORAGE_DEFAULT_ACL: "private"
+        CLOUDFRONT_DOMAIN: wp-muckrock-prod.news-engineering.aws.wapo.pub
+        MAILGUN_SERVER_NAME: foi-requests.washpost.com
 
     - name: muckrock_celerybeat
       image: muckrock_celerybeat

--- a/muckrock/settings/wapo/local.py
+++ b/muckrock/settings/wapo/local.py
@@ -6,5 +6,3 @@ AWS_MEDIA_BUCKET_NAME="wp-muckrock-uploads-dev"
 CLOUDFRONT_DOMAIN="wp-muckrock-dev.news-engineering.aws.wapo.pub"
 AWS_STORAGE_DEFAULT_ACL="private"
 AWS_MEDIA_QUERYSTRING_AUTH=True
-
-MAILGUN_DOMAIN = "foia-requests-dev.news-engineering.aws.wapo.pub"

--- a/muckrock/settings/wapo/production.py
+++ b/muckrock/settings/wapo/production.py
@@ -20,14 +20,6 @@ BANDIT_WHITELIST = [
 
 SECURE_SSL_REDIRECT = False
 
-AWS_STORAGE_BUCKET_NAME="wp-muckrock-prod"
-AWS_MEDIA_BUCKET_NAME="wp-muckrock-uploads-prod"
-CLOUDFRONT_DOMAIN="wp-muckrock-prod.news-engineering.aws.wapo.pub"
-AWS_STORAGE_DEFAULT_ACL="private"
-AWS_MEDIA_QUERYSTRING_AUTH=True
-
-MAILGUN_DOMAIN = "foi-requests.washpost.com"
-
 # This gets the IP address of the EC2 instance the task is
 # running on and adds it to allowed_hosts so the health
 # check will work

--- a/muckrock/settings/wapo/staging.py
+++ b/muckrock/settings/wapo/staging.py
@@ -13,14 +13,6 @@ UNINSTALLED_APPS = ["scout_apm.django"]
 INSTALLED_APPS = [app for app in INSTALLED_APPS if app not in UNINSTALLED_APPS]
 USE_SCOUT = False
 
-AWS_STORAGE_BUCKET_NAME="wp-muckrock-dev"
-AWS_MEDIA_BUCKET_NAME="wp-muckrock-uploads-dev"
-CLOUDFRONT_DOMAIN="wp-muckrock-dev.news-engineering.aws.wapo.pub"
-AWS_STORAGE_DEFAULT_ACL="private"
-AWS_MEDIA_QUERYSTRING_AUTH=True
-
-MAILGUN_DOMAIN = "foia-requests-dev.news-engineering.aws.wapo.pub"
-
 # This gets the IP address of the EC2 instance the task is
 # running on and adds it to allowed_hosts so the health
 # check will work


### PR DESCRIPTION
Ok I'm going to take you on a journey 🧙‍♂️ 🚶 ✨ 

1. The deploy failed.

me 👶 : 🤔 

2. The logs in [cloudwatch](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/muckrock-dev/log-events/dev$252Fmuckrock_django$252F9f00e62e17a24400b475558f0487a88b) seemed to indicate django failed the `python manage.py compress` step in the entrypoint because 
> CommandError: An error occurred during rendering /app/muckrock/templates/communication/check_list.html: 'https://wp-muckrock-dev.s3.amazonaws.com/hijack/hijack-styles.css' isn't accessible via COMPRESS_URL ('https://muckrock-devel2.s3.amazonaws.com/') and can't be compressed

👿

Wait, why is the `COMPRESS_URL` set to `https://muckrock-devel2.s3.amazonaws...`, oh thats the default in `muckrock.settings.base.py`, which is read from the environment. 

The new pattern in our settings files now allow us to override everything in our base settings file at `muckrock.settings.wapo.base.py` BUT this suggests there may be an issue, since its using Muckrock's defaults.

```
from muckrock.settings.staging import *
from muckrock.settings.wapo.base import *
``` 
💡 

Except I realized that importing * from `muckrock.settings.staging` means it is re-binding those settings using the environment variables, and when those aren't defined it uses the defaults, hence `muckrock-devel2`. I tested this in locally removing the missing vars from my `.env` file and it mimicked the behavior, and was fixed by adding them back in. 

There is probably a way to do this without putting them in the config, but I think it is just clearer that way, so we can see at a top level what all the values are from ECS. 

In short, everything is terrible but I blame `import *` syntax. 